### PR TITLE
Add agent_options keepAlive / timeout to verdaccio.yml

### DIFF
--- a/verdaccio.yml
+++ b/verdaccio.yml
@@ -8,11 +8,13 @@ uplinks:
     timeout: 10m
     fail_timeout: 10m
     max_fails: 20
+    agent_options: { keepAlive: true, keepAliveMsecs: 10000, timeout: 100000 }
   yarn:
     url: https://registry.yarnpkg.com/
     timeout: 10m
     fail_timeout: 10m
     max_fails: 20
+    agent_options: { keepAlive: true, keepAliveMsecs: 10000, timeout: 100000 }
 packages:
   '@*/*':
     # scoped packages


### PR DESCRIPTION
## Description

Found yet another place in the verdaccio.yml where timeouts can be set (lol). This one worked for both ganache and mosaic ([at least once][1]). 

Opening to see if it works twice.

[1]: https://github.com/cgewecke/web3.js/pull/2/checks?check_run_id=481402153