### PR TITLE
Test fixing CI build

### DIFF
--- a/packages/web3-bzz/package-lock.json
+++ b/packages/web3-bzz/package-lock.json
@@ -480,16 +480,6 @@
 			"resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
 			"integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ=="
 		},
-		"definitelytyped-header-parser": {
-			"version": "3.9.0",
-			"resolved": "https://registry.npmjs.org/definitelytyped-header-parser/-/definitelytyped-header-parser-3.9.0.tgz",
-			"integrity": "sha512-slbwZ5h5lasB12t+9EAGYr060aCMqEXp6cwD7CoTriK40HNDYU56/XQ6S4sbjBK8ReGRMnB/uDx0elKkb4kuQA==",
-			"dev": true,
-			"requires": {
-				"@types/parsimmon": "^1.3.0",
-				"parsimmon": "^1.2.0"
-			}
-		},
 		"delayed-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -579,7 +569,6 @@
 				"json-stable-stringify": "^1.0.1",
 				"strip-json-comments": "^2.0.1",
 				"tslint": "5.14.0",
-				"typescript": "^3.9.0-dev.20200409",
 				"yargs": "^15.1.0"
 			},
 			"dependencies": {
@@ -603,6 +592,11 @@
 						"jsonfile": "^4.0.0",
 						"universalify": "^0.1.0"
 					}
+				},
+				"typescript": {
+					"version": "3.9.0-dev.20200417",
+					"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.0-dev.20200417.tgz",
+					"integrity": "sha512-VjLaL/mz6HfZb76uFyxcMrT2HriDQErE28rC5g7owTmKGHnwl56OauZIIYqL0wQk6JkWCb54XC+oio3CQ1rHyA=="
 				}
 			}
 		},
@@ -2042,9 +2036,9 @@
 			}
 		},
 		"typescript": {
-			"version": "3.9.0-dev.20200409",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.0-dev.20200409.tgz",
-			"integrity": "sha512-S6rqgD9K1y3vva/2g6GSwtkg6RC8W74ssTq52NtpS/ujqptYOJIgWHnMK+QN9yjFk2fzJfH9/TIMeFnLkZyHZg==",
+			"version": "3.8.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+			"integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
 			"dev": true
 		},
 		"ultron": {

--- a/packages/web3-bzz/package.json
+++ b/packages/web3-bzz/package.json
@@ -9,7 +9,7 @@
     },
     "types": "types/index.d.ts",
     "scripts": {
-        "dtslint": "dtslint types"
+        "dtslint": "dtslint --localTs node_modules/typescript/lib types"
     },
     "main": "src/index.js",
     "dependencies": {
@@ -19,7 +19,7 @@
         "underscore": "1.9.1"
     },
     "devDependencies": {
-        "definitelytyped-header-parser": "^3.9.0",
-        "dtslint": "^3.4.1"
+        "dtslint": "^3.4.1",
+        "typescript": "latest"
     }
 }

--- a/packages/web3-bzz/types/index.d.ts
+++ b/packages/web3-bzz/types/index.d.ts
@@ -17,8 +17,6 @@
  * @date 2018
  */
 
-// Minimum TypeScript Version: 3.0
-
 export class Bzz {
     constructor();
     constructor(provider: any);

--- a/packages/web3-core-helpers/package-lock.json
+++ b/packages/web3-core-helpers/package-lock.json
@@ -220,16 +220,6 @@
 			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
 			"dev": true
 		},
-		"definitelytyped-header-parser": {
-			"version": "3.9.0",
-			"resolved": "https://registry.npmjs.org/definitelytyped-header-parser/-/definitelytyped-header-parser-3.9.0.tgz",
-			"integrity": "sha512-slbwZ5h5lasB12t+9EAGYr060aCMqEXp6cwD7CoTriK40HNDYU56/XQ6S4sbjBK8ReGRMnB/uDx0elKkb4kuQA==",
-			"dev": true,
-			"requires": {
-				"@types/parsimmon": "^1.3.0",
-				"parsimmon": "^1.2.0"
-			}
-		},
 		"diff": {
 			"version": "3.5.0",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
@@ -299,7 +289,6 @@
 				"json-stable-stringify": "^1.0.1",
 				"strip-json-comments": "^2.0.1",
 				"tslint": "5.14.0",
-				"typescript": "^3.9.0-dev.20200409",
 				"yargs": "^15.1.0"
 			},
 			"dependencies": {
@@ -312,6 +301,11 @@
 						"@types/parsimmon": "^1.3.0",
 						"parsimmon": "^1.2.0"
 					}
+				},
+				"typescript": {
+					"version": "3.9.0-dev.20200417",
+					"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.0-dev.20200417.tgz",
+					"integrity": "sha512-VjLaL/mz6HfZb76uFyxcMrT2HriDQErE28rC5g7owTmKGHnwl56OauZIIYqL0wQk6JkWCb54XC+oio3CQ1rHyA=="
 				}
 			}
 		},
@@ -861,9 +855,9 @@
 			}
 		},
 		"typescript": {
-			"version": "3.9.0-dev.20200409",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.0-dev.20200409.tgz",
-			"integrity": "sha512-S6rqgD9K1y3vva/2g6GSwtkg6RC8W74ssTq52NtpS/ujqptYOJIgWHnMK+QN9yjFk2fzJfH9/TIMeFnLkZyHZg==",
+			"version": "3.8.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+			"integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
 			"dev": true
 		},
 		"underscore": {

--- a/packages/web3-core-helpers/package.json
+++ b/packages/web3-core-helpers/package.json
@@ -9,7 +9,7 @@
     },
     "types": "types/index.d.ts",
     "scripts": {
-        "dtslint": "dtslint types"
+        "dtslint": "dtslint --localTs node_modules/typescript/lib types"
     },
     "main": "src/index.js",
     "dependencies": {
@@ -19,7 +19,7 @@
     },
     "devDependencies": {
         "@types/node": "^12.12.5",
-        "definitelytyped-header-parser": "^3.9.0",
-        "dtslint": "^3.4.1"
+        "dtslint": "^3.4.1",
+        "typescript": "latest"
     }
 }

--- a/packages/web3-core-helpers/types/index.d.ts
+++ b/packages/web3-core-helpers/types/index.d.ts
@@ -17,8 +17,6 @@
  * @date 2018
  */
 
-// Minimum TypeScript Version: 3.0
-
 import * as net from 'net';
 import * as http from 'http';
 import * as https from 'https';

--- a/packages/web3-core-method/package-lock.json
+++ b/packages/web3-core-method/package-lock.json
@@ -214,16 +214,6 @@
 			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
 			"dev": true
 		},
-		"definitelytyped-header-parser": {
-			"version": "3.9.0",
-			"resolved": "https://registry.npmjs.org/definitelytyped-header-parser/-/definitelytyped-header-parser-3.9.0.tgz",
-			"integrity": "sha512-slbwZ5h5lasB12t+9EAGYr060aCMqEXp6cwD7CoTriK40HNDYU56/XQ6S4sbjBK8ReGRMnB/uDx0elKkb4kuQA==",
-			"dev": true,
-			"requires": {
-				"@types/parsimmon": "^1.3.0",
-				"parsimmon": "^1.2.0"
-			}
-		},
 		"diff": {
 			"version": "3.5.0",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
@@ -293,7 +283,6 @@
 				"json-stable-stringify": "^1.0.1",
 				"strip-json-comments": "^2.0.1",
 				"tslint": "5.14.0",
-				"typescript": "^3.9.0-dev.20200409",
 				"yargs": "^15.1.0"
 			},
 			"dependencies": {
@@ -306,6 +295,11 @@
 						"@types/parsimmon": "^1.3.0",
 						"parsimmon": "^1.2.0"
 					}
+				},
+				"typescript": {
+					"version": "3.9.0-dev.20200417",
+					"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.0-dev.20200417.tgz",
+					"integrity": "sha512-VjLaL/mz6HfZb76uFyxcMrT2HriDQErE28rC5g7owTmKGHnwl56OauZIIYqL0wQk6JkWCb54XC+oio3CQ1rHyA=="
 				}
 			}
 		},
@@ -855,9 +849,9 @@
 			}
 		},
 		"typescript": {
-			"version": "3.9.0-dev.20200409",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.0-dev.20200409.tgz",
-			"integrity": "sha512-S6rqgD9K1y3vva/2g6GSwtkg6RC8W74ssTq52NtpS/ujqptYOJIgWHnMK+QN9yjFk2fzJfH9/TIMeFnLkZyHZg==",
+			"version": "3.8.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+			"integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
 			"dev": true
 		},
 		"underscore": {

--- a/packages/web3-core-method/package.json
+++ b/packages/web3-core-method/package.json
@@ -9,7 +9,7 @@
     },
     "types": "types/index.d.ts",
     "scripts": {
-        "dtslint": "dtslint types"
+        "dtslint": "dtslint --localTs node_modules/typescript/lib types"
     },
     "main": "src/index.js",
     "dependencies": {
@@ -20,7 +20,7 @@
         "web3-utils": "1.2.6"
     },
     "devDependencies": {
-        "definitelytyped-header-parser": "^3.9.0",
-        "dtslint": "^3.4.1"
+        "dtslint": "^3.4.1",
+        "typescript": "latest"
     }
 }

--- a/packages/web3-core-method/types/index.d.ts
+++ b/packages/web3-core-method/types/index.d.ts
@@ -17,8 +17,6 @@
  * @date 2018
  */
 
-// Minimum TypeScript Version: 3.0
-
 import {JsonRpcPayload} from 'web3-core-helpers';
 
 export interface Method {

--- a/packages/web3-core-subscriptions/package-lock.json
+++ b/packages/web3-core-subscriptions/package-lock.json
@@ -214,16 +214,6 @@
 			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
 			"dev": true
 		},
-		"definitelytyped-header-parser": {
-			"version": "3.9.0",
-			"resolved": "https://registry.npmjs.org/definitelytyped-header-parser/-/definitelytyped-header-parser-3.9.0.tgz",
-			"integrity": "sha512-slbwZ5h5lasB12t+9EAGYr060aCMqEXp6cwD7CoTriK40HNDYU56/XQ6S4sbjBK8ReGRMnB/uDx0elKkb4kuQA==",
-			"dev": true,
-			"requires": {
-				"@types/parsimmon": "^1.3.0",
-				"parsimmon": "^1.2.0"
-			}
-		},
 		"diff": {
 			"version": "3.5.0",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
@@ -293,7 +283,6 @@
 				"json-stable-stringify": "^1.0.1",
 				"strip-json-comments": "^2.0.1",
 				"tslint": "5.14.0",
-				"typescript": "^3.9.0-dev.20200409",
 				"yargs": "^15.1.0"
 			},
 			"dependencies": {
@@ -306,6 +295,11 @@
 						"@types/parsimmon": "^1.3.0",
 						"parsimmon": "^1.2.0"
 					}
+				},
+				"typescript": {
+					"version": "3.9.0-dev.20200417",
+					"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.0-dev.20200417.tgz",
+					"integrity": "sha512-VjLaL/mz6HfZb76uFyxcMrT2HriDQErE28rC5g7owTmKGHnwl56OauZIIYqL0wQk6JkWCb54XC+oio3CQ1rHyA=="
 				}
 			}
 		},
@@ -860,9 +854,9 @@
 			}
 		},
 		"typescript": {
-			"version": "3.9.0-dev.20200409",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.0-dev.20200409.tgz",
-			"integrity": "sha512-S6rqgD9K1y3vva/2g6GSwtkg6RC8W74ssTq52NtpS/ujqptYOJIgWHnMK+QN9yjFk2fzJfH9/TIMeFnLkZyHZg==",
+			"version": "3.8.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+			"integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
 			"dev": true
 		},
 		"underscore": {

--- a/packages/web3-core-subscriptions/package.json
+++ b/packages/web3-core-subscriptions/package.json
@@ -9,7 +9,7 @@
     },
     "types": "types/index.d.ts",
     "scripts": {
-        "dtslint": "dtslint types"
+        "dtslint": "dtslint --localTs node_modules/typescript/lib types"
     },
     "main": "src/index.js",
     "dependencies": {
@@ -18,7 +18,7 @@
         "web3-core-helpers": "1.2.6"
     },
     "devDependencies": {
-        "definitelytyped-header-parser": "^3.9.0",
-        "dtslint": "^3.4.1"
+        "dtslint": "^3.4.1",
+        "typescript": "latest"
     }
 }

--- a/packages/web3-core-subscriptions/types/index.d.ts
+++ b/packages/web3-core-subscriptions/types/index.d.ts
@@ -17,8 +17,6 @@
  * @date 2019
  */
 
-// Minimum TypeScript Version: 3.7
-
 export class Subscription<T> {
     constructor(options: SubscriptionOptions);
 

--- a/packages/web3-core/package-lock.json
+++ b/packages/web3-core/package-lock.json
@@ -232,16 +232,6 @@
 			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
 			"dev": true
 		},
-		"definitelytyped-header-parser": {
-			"version": "3.9.0",
-			"resolved": "https://registry.npmjs.org/definitelytyped-header-parser/-/definitelytyped-header-parser-3.9.0.tgz",
-			"integrity": "sha512-slbwZ5h5lasB12t+9EAGYr060aCMqEXp6cwD7CoTriK40HNDYU56/XQ6S4sbjBK8ReGRMnB/uDx0elKkb4kuQA==",
-			"dev": true,
-			"requires": {
-				"@types/parsimmon": "^1.3.0",
-				"parsimmon": "^1.2.0"
-			}
-		},
 		"diff": {
 			"version": "3.5.0",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
@@ -877,6 +867,12 @@
 			"requires": {
 				"tslib": "^1.8.1"
 			}
+		},
+		"typescript": {
+			"version": "3.8.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+			"integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
+			"dev": true
 		},
 		"universalify": {
 			"version": "0.1.2",

--- a/packages/web3-core/package.json
+++ b/packages/web3-core/package.json
@@ -9,7 +9,7 @@
     },
     "types": "types/index.d.ts",
     "scripts": {
-        "dtslint": "dtslint types"
+        "dtslint": "dtslint --localTs node_modules/typescript/lib types"
     },
     "main": "src/index.js",
     "dependencies": {
@@ -22,7 +22,7 @@
         "web3-utils": "1.2.6"
     },
     "devDependencies": {
-        "definitelytyped-header-parser": "^3.9.0",
-        "dtslint": "^3.4.1"
+        "dtslint": "^3.4.1",
+        "typescript": "latest"
     }
 }

--- a/packages/web3-core/types/index.d.ts
+++ b/packages/web3-core/types/index.d.ts
@@ -18,8 +18,6 @@
  * @date 2018
  */
 
-// Minimum TypeScript Version: 3.0
-
 import * as net from 'net';
 import {
     HttpProviderBase,

--- a/packages/web3-eth-abi/package-lock.json
+++ b/packages/web3-eth-abi/package-lock.json
@@ -234,16 +234,6 @@
 			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
 			"dev": true
 		},
-		"definitelytyped-header-parser": {
-			"version": "3.9.0",
-			"resolved": "https://registry.npmjs.org/definitelytyped-header-parser/-/definitelytyped-header-parser-3.9.0.tgz",
-			"integrity": "sha512-slbwZ5h5lasB12t+9EAGYr060aCMqEXp6cwD7CoTriK40HNDYU56/XQ6S4sbjBK8ReGRMnB/uDx0elKkb4kuQA==",
-			"dev": true,
-			"requires": {
-				"@types/parsimmon": "^1.3.0",
-				"parsimmon": "^1.2.0"
-			}
-		},
 		"diff": {
 			"version": "3.5.0",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
@@ -313,7 +303,6 @@
 				"json-stable-stringify": "^1.0.1",
 				"strip-json-comments": "^2.0.1",
 				"tslint": "5.14.0",
-				"typescript": "^3.9.0-dev.20200409",
 				"yargs": "^15.1.0"
 			},
 			"dependencies": {
@@ -326,6 +315,11 @@
 						"@types/parsimmon": "^1.3.0",
 						"parsimmon": "^1.2.0"
 					}
+				},
+				"typescript": {
+					"version": "3.9.0-dev.20200417",
+					"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.0-dev.20200417.tgz",
+					"integrity": "sha512-VjLaL/mz6HfZb76uFyxcMrT2HriDQErE28rC5g7owTmKGHnwl56OauZIIYqL0wQk6JkWCb54XC+oio3CQ1rHyA=="
 				}
 			}
 		},
@@ -931,9 +925,9 @@
 			}
 		},
 		"typescript": {
-			"version": "3.9.0-dev.20200409",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.0-dev.20200409.tgz",
-			"integrity": "sha512-S6rqgD9K1y3vva/2g6GSwtkg6RC8W74ssTq52NtpS/ujqptYOJIgWHnMK+QN9yjFk2fzJfH9/TIMeFnLkZyHZg==",
+			"version": "3.8.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+			"integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
 			"dev": true
 		},
 		"underscore": {

--- a/packages/web3-eth-abi/package.json
+++ b/packages/web3-eth-abi/package.json
@@ -9,7 +9,7 @@
     },
     "types": "types/index.d.ts",
     "scripts": {
-        "dtslint": "dtslint types"
+        "dtslint": "dtslint --localTs node_modules/typescript/lib  types"
     },
     "main": "src/index.js",
     "dependencies": {
@@ -18,7 +18,7 @@
         "web3-utils": "1.2.6"
     },
     "devDependencies": {
-        "definitelytyped-header-parser": "^3.9.0",
-        "dtslint": "^3.4.1"
+        "dtslint": "^3.4.1",
+        "typescript": "latest"
     }
 }

--- a/packages/web3-eth-abi/types/index.d.ts
+++ b/packages/web3-eth-abi/types/index.d.ts
@@ -17,8 +17,6 @@
  * @date 2018
  */
 
-// Minimum TypeScript Version: 3.0
-
 import { AbiInput, AbiItem } from 'web3-utils';
 
 export class AbiCoder {

--- a/packages/web3-eth-accounts/package-lock.json
+++ b/packages/web3-eth-accounts/package-lock.json
@@ -413,16 +413,6 @@
 				"mimic-response": "^1.0.0"
 			}
 		},
-		"definitelytyped-header-parser": {
-			"version": "3.9.0",
-			"resolved": "https://registry.npmjs.org/definitelytyped-header-parser/-/definitelytyped-header-parser-3.9.0.tgz",
-			"integrity": "sha512-slbwZ5h5lasB12t+9EAGYr060aCMqEXp6cwD7CoTriK40HNDYU56/XQ6S4sbjBK8ReGRMnB/uDx0elKkb4kuQA==",
-			"dev": true,
-			"requires": {
-				"@types/parsimmon": "^1.3.0",
-				"parsimmon": "^1.2.0"
-			}
-		},
 		"des.js": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",
@@ -1433,6 +1423,12 @@
 			"requires": {
 				"tslib": "^1.8.1"
 			}
+		},
+		"typescript": {
+			"version": "3.8.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+			"integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
+			"dev": true
 		},
 		"underscore": {
 			"version": "1.9.1",

--- a/packages/web3-eth-accounts/package.json
+++ b/packages/web3-eth-accounts/package.json
@@ -9,7 +9,7 @@
     },
     "types": "types/index.d.ts",
     "scripts": {
-        "dtslint": "dtslint types"
+        "dtslint": "dtslint --localTs node_modules/typescript/lib  types"
     },
     "main": "src/index.js",
     "dependencies": {
@@ -26,7 +26,7 @@
         "web3-utils": "1.2.6"
     },
     "devDependencies": {
-        "definitelytyped-header-parser": "^3.9.0",
-        "dtslint": "^3.4.1"
+        "dtslint": "^3.4.1",
+        "typescript": "latest"
     }
 }

--- a/packages/web3-eth-accounts/types/index.d.ts
+++ b/packages/web3-eth-accounts/types/index.d.ts
@@ -17,8 +17,6 @@
  * @date 2018
  */
 
-// Minimum TypeScript Version: 3.0
-
 import { AccountsBase, SignedTransaction, WalletBase } from 'web3-core';
 
 export {SignedTransaction} from 'web3-core';

--- a/packages/web3-eth-contract/package-lock.json
+++ b/packages/web3-eth-contract/package-lock.json
@@ -227,16 +227,6 @@
 			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
 			"dev": true
 		},
-		"definitelytyped-header-parser": {
-			"version": "3.9.0",
-			"resolved": "https://registry.npmjs.org/definitelytyped-header-parser/-/definitelytyped-header-parser-3.9.0.tgz",
-			"integrity": "sha512-slbwZ5h5lasB12t+9EAGYr060aCMqEXp6cwD7CoTriK40HNDYU56/XQ6S4sbjBK8ReGRMnB/uDx0elKkb4kuQA==",
-			"dev": true,
-			"requires": {
-				"@types/parsimmon": "^1.3.0",
-				"parsimmon": "^1.2.0"
-			}
-		},
 		"diff": {
 			"version": "3.5.0",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
@@ -306,7 +296,6 @@
 				"json-stable-stringify": "^1.0.1",
 				"strip-json-comments": "^2.0.1",
 				"tslint": "5.14.0",
-				"typescript": "^3.9.0-dev.20200409",
 				"yargs": "^15.1.0"
 			},
 			"dependencies": {
@@ -319,6 +308,11 @@
 						"@types/parsimmon": "^1.3.0",
 						"parsimmon": "^1.2.0"
 					}
+				},
+				"typescript": {
+					"version": "3.9.0-dev.20200417",
+					"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.0-dev.20200417.tgz",
+					"integrity": "sha512-VjLaL/mz6HfZb76uFyxcMrT2HriDQErE28rC5g7owTmKGHnwl56OauZIIYqL0wQk6JkWCb54XC+oio3CQ1rHyA=="
 				}
 			}
 		},
@@ -868,9 +862,9 @@
 			}
 		},
 		"typescript": {
-			"version": "3.9.0-dev.20200409",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.0-dev.20200409.tgz",
-			"integrity": "sha512-S6rqgD9K1y3vva/2g6GSwtkg6RC8W74ssTq52NtpS/ujqptYOJIgWHnMK+QN9yjFk2fzJfH9/TIMeFnLkZyHZg==",
+			"version": "3.8.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+			"integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
 			"dev": true
 		},
 		"underscore": {

--- a/packages/web3-eth-contract/package.json
+++ b/packages/web3-eth-contract/package.json
@@ -9,7 +9,7 @@
     },
     "types": "types/index.d.ts",
     "scripts": {
-        "dtslint": "dtslint types"
+        "dtslint": "dtslint --localTs node_modules/typescript/lib types"
     },
     "main": "src/index.js",
     "dependencies": {
@@ -24,7 +24,7 @@
         "web3-utils": "1.2.6"
     },
     "devDependencies": {
-        "definitelytyped-header-parser": "^3.9.0",
-        "dtslint": "^3.4.1"
+        "dtslint": "^3.4.1",
+        "typescript": "latest"
     }
 }

--- a/packages/web3-eth-contract/types/index.d.ts
+++ b/packages/web3-eth-contract/types/index.d.ts
@@ -17,8 +17,6 @@
  * @date 2018
  */
 
-// Minimum TypeScript Version: 3.0
-
 import BN = require('bn.js');
 import {Common, PromiEvent, provider, hardfork, chain, BlockNumber, PastLogsOptions, LogsOptions} from 'web3-core';
 import {AbiItem} from 'web3-utils';

--- a/packages/web3-eth-ens/package-lock.json
+++ b/packages/web3-eth-ens/package-lock.json
@@ -214,16 +214,6 @@
 			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
 			"dev": true
 		},
-		"definitelytyped-header-parser": {
-			"version": "3.9.0",
-			"resolved": "https://registry.npmjs.org/definitelytyped-header-parser/-/definitelytyped-header-parser-3.9.0.tgz",
-			"integrity": "sha512-slbwZ5h5lasB12t+9EAGYr060aCMqEXp6cwD7CoTriK40HNDYU56/XQ6S4sbjBK8ReGRMnB/uDx0elKkb4kuQA==",
-			"dev": true,
-			"requires": {
-				"@types/parsimmon": "^1.3.0",
-				"parsimmon": "^1.2.0"
-			}
-		},
 		"diff": {
 			"version": "3.5.0",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
@@ -293,7 +283,6 @@
 				"json-stable-stringify": "^1.0.1",
 				"strip-json-comments": "^2.0.1",
 				"tslint": "5.14.0",
-				"typescript": "^3.9.0-dev.20200409",
 				"yargs": "^15.1.0"
 			},
 			"dependencies": {
@@ -306,6 +295,11 @@
 						"@types/parsimmon": "^1.3.0",
 						"parsimmon": "^1.2.0"
 					}
+				},
+				"typescript": {
+					"version": "3.9.0-dev.20200417",
+					"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.0-dev.20200417.tgz",
+					"integrity": "sha512-VjLaL/mz6HfZb76uFyxcMrT2HriDQErE28rC5g7owTmKGHnwl56OauZIIYqL0wQk6JkWCb54XC+oio3CQ1rHyA=="
 				}
 			}
 		},
@@ -882,9 +876,9 @@
 			}
 		},
 		"typescript": {
-			"version": "3.9.0-dev.20200409",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.0-dev.20200409.tgz",
-			"integrity": "sha512-S6rqgD9K1y3vva/2g6GSwtkg6RC8W74ssTq52NtpS/ujqptYOJIgWHnMK+QN9yjFk2fzJfH9/TIMeFnLkZyHZg==",
+			"version": "3.8.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+			"integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
 			"dev": true
 		},
 		"underscore": {

--- a/packages/web3-eth-ens/package.json
+++ b/packages/web3-eth-ens/package.json
@@ -9,7 +9,7 @@
     },
     "types": "types/index.d.ts",
     "scripts": {
-        "dtslint": "dtslint types"
+        "dtslint": "dtslint --localTs node_modules/typescript/lib  types"
     },
     "main": "src/index.js",
     "dependencies": {
@@ -23,7 +23,7 @@
         "web3-utils": "1.2.6"
     },
     "devDependencies": {
-        "definitelytyped-header-parser": "^3.9.0",
-        "dtslint": "^3.4.1"
+        "dtslint": "^3.4.1",
+        "typescript": "latest"
     }
 }

--- a/packages/web3-eth-ens/types/index.d.ts
+++ b/packages/web3-eth-ens/types/index.d.ts
@@ -17,8 +17,6 @@
  * @date 2018
  */
 
-// Minimum TypeScript Version: 3.0
-
 import { PromiEvent, TransactionConfig, TransactionReceipt } from 'web3-core';
 import { TransactionRevertInstructionError } from 'web3-core-helpers';
 import { Eth } from 'web3-eth';

--- a/packages/web3-eth-iban/package-lock.json
+++ b/packages/web3-eth-iban/package-lock.json
@@ -219,16 +219,6 @@
 			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
 			"dev": true
 		},
-		"definitelytyped-header-parser": {
-			"version": "3.9.0",
-			"resolved": "https://registry.npmjs.org/definitelytyped-header-parser/-/definitelytyped-header-parser-3.9.0.tgz",
-			"integrity": "sha512-slbwZ5h5lasB12t+9EAGYr060aCMqEXp6cwD7CoTriK40HNDYU56/XQ6S4sbjBK8ReGRMnB/uDx0elKkb4kuQA==",
-			"dev": true,
-			"requires": {
-				"@types/parsimmon": "^1.3.0",
-				"parsimmon": "^1.2.0"
-			}
-		},
 		"diff": {
 			"version": "3.5.0",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
@@ -298,7 +288,6 @@
 				"json-stable-stringify": "^1.0.1",
 				"strip-json-comments": "^2.0.1",
 				"tslint": "5.14.0",
-				"typescript": "^3.9.0-dev.20200409",
 				"yargs": "^15.1.0"
 			},
 			"dependencies": {
@@ -311,6 +300,11 @@
 						"@types/parsimmon": "^1.3.0",
 						"parsimmon": "^1.2.0"
 					}
+				},
+				"typescript": {
+					"version": "3.9.0-dev.20200417",
+					"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.0-dev.20200417.tgz",
+					"integrity": "sha512-VjLaL/mz6HfZb76uFyxcMrT2HriDQErE28rC5g7owTmKGHnwl56OauZIIYqL0wQk6JkWCb54XC+oio3CQ1rHyA=="
 				}
 			}
 		},
@@ -860,9 +854,9 @@
 			}
 		},
 		"typescript": {
-			"version": "3.9.0-dev.20200409",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.0-dev.20200409.tgz",
-			"integrity": "sha512-S6rqgD9K1y3vva/2g6GSwtkg6RC8W74ssTq52NtpS/ujqptYOJIgWHnMK+QN9yjFk2fzJfH9/TIMeFnLkZyHZg==",
+			"version": "3.8.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+			"integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
 			"dev": true
 		},
 		"universalify": {

--- a/packages/web3-eth-iban/package.json
+++ b/packages/web3-eth-iban/package.json
@@ -9,7 +9,7 @@
     },
     "types": "types/index.d.ts",
     "scripts": {
-        "dtslint": "dtslint types"
+        "dtslint": "dtslint --localTs node_modules/typescript/lib types"
     },
     "main": "src/index.js",
     "dependencies": {
@@ -17,7 +17,7 @@
         "web3-utils": "1.2.6"
     },
     "devDependencies": {
-        "definitelytyped-header-parser": "^3.9.0",
-        "dtslint": "^3.4.1"
+        "dtslint": "^3.4.1",
+        "typescript": "latest"
     }
 }

--- a/packages/web3-eth-iban/types/index.d.ts
+++ b/packages/web3-eth-iban/types/index.d.ts
@@ -20,8 +20,6 @@
  * @date 2018
  */
 
-// Minimum TypeScript Version: 3.0
-
 export class Iban {
     constructor(
         iban: string

--- a/packages/web3-eth-personal/package-lock.json
+++ b/packages/web3-eth-personal/package-lock.json
@@ -219,16 +219,6 @@
 			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
 			"dev": true
 		},
-		"definitelytyped-header-parser": {
-			"version": "3.9.0",
-			"resolved": "https://registry.npmjs.org/definitelytyped-header-parser/-/definitelytyped-header-parser-3.9.0.tgz",
-			"integrity": "sha512-slbwZ5h5lasB12t+9EAGYr060aCMqEXp6cwD7CoTriK40HNDYU56/XQ6S4sbjBK8ReGRMnB/uDx0elKkb4kuQA==",
-			"dev": true,
-			"requires": {
-				"@types/parsimmon": "^1.3.0",
-				"parsimmon": "^1.2.0"
-			}
-		},
 		"diff": {
 			"version": "3.5.0",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
@@ -298,7 +288,6 @@
 				"json-stable-stringify": "^1.0.1",
 				"strip-json-comments": "^2.0.1",
 				"tslint": "5.14.0",
-				"typescript": "^3.9.0-dev.20200409",
 				"yargs": "^15.1.0"
 			},
 			"dependencies": {
@@ -311,6 +300,11 @@
 						"@types/parsimmon": "^1.3.0",
 						"parsimmon": "^1.2.0"
 					}
+				},
+				"typescript": {
+					"version": "3.9.0-dev.20200417",
+					"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.0-dev.20200417.tgz",
+					"integrity": "sha512-VjLaL/mz6HfZb76uFyxcMrT2HriDQErE28rC5g7owTmKGHnwl56OauZIIYqL0wQk6JkWCb54XC+oio3CQ1rHyA=="
 				}
 			}
 		},
@@ -860,9 +854,9 @@
 			}
 		},
 		"typescript": {
-			"version": "3.9.0-dev.20200409",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.0-dev.20200409.tgz",
-			"integrity": "sha512-S6rqgD9K1y3vva/2g6GSwtkg6RC8W74ssTq52NtpS/ujqptYOJIgWHnMK+QN9yjFk2fzJfH9/TIMeFnLkZyHZg==",
+			"version": "3.8.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+			"integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
 			"dev": true
 		},
 		"universalify": {

--- a/packages/web3-eth-personal/package.json
+++ b/packages/web3-eth-personal/package.json
@@ -9,7 +9,7 @@
     },
     "types": "types/index.d.ts",
     "scripts": {
-        "dtslint": "dtslint types"
+        "dtslint": "dtslint --localTs node_modules/typescript/lib types"
     },
     "main": "src/index.js",
     "dependencies": {
@@ -21,7 +21,7 @@
         "web3-utils": "1.2.6"
     },
     "devDependencies": {
-        "definitelytyped-header-parser": "^3.9.0",
-        "dtslint": "^3.4.1"
+        "dtslint": "^3.4.1",
+        "typescript": "latest"
     }
 }

--- a/packages/web3-eth-personal/types/index.d.ts
+++ b/packages/web3-eth-personal/types/index.d.ts
@@ -18,8 +18,6 @@
  * @date 2018
  */
 
-// Minimum TypeScript Version: 3.0
-
 import * as net from 'net';
 import { provider, RLPEncodedTransaction, TransactionConfig, BatchRequest, Providers, Extension } from 'web3-core';
 

--- a/packages/web3-eth/package-lock.json
+++ b/packages/web3-eth/package-lock.json
@@ -214,16 +214,6 @@
 			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
 			"dev": true
 		},
-		"definitelytyped-header-parser": {
-			"version": "3.9.0",
-			"resolved": "https://registry.npmjs.org/definitelytyped-header-parser/-/definitelytyped-header-parser-3.9.0.tgz",
-			"integrity": "sha512-slbwZ5h5lasB12t+9EAGYr060aCMqEXp6cwD7CoTriK40HNDYU56/XQ6S4sbjBK8ReGRMnB/uDx0elKkb4kuQA==",
-			"dev": true,
-			"requires": {
-				"@types/parsimmon": "^1.3.0",
-				"parsimmon": "^1.2.0"
-			}
-		},
 		"diff": {
 			"version": "3.5.0",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
@@ -293,7 +283,6 @@
 				"json-stable-stringify": "^1.0.1",
 				"strip-json-comments": "^2.0.1",
 				"tslint": "5.14.0",
-				"typescript": "^3.9.0-dev.20200409",
 				"yargs": "^15.1.0"
 			},
 			"dependencies": {
@@ -306,6 +295,11 @@
 						"@types/parsimmon": "^1.3.0",
 						"parsimmon": "^1.2.0"
 					}
+				},
+				"typescript": {
+					"version": "3.9.0-dev.20200417",
+					"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.0-dev.20200417.tgz",
+					"integrity": "sha512-VjLaL/mz6HfZb76uFyxcMrT2HriDQErE28rC5g7owTmKGHnwl56OauZIIYqL0wQk6JkWCb54XC+oio3CQ1rHyA=="
 				}
 			}
 		},
@@ -855,9 +849,9 @@
 			}
 		},
 		"typescript": {
-			"version": "3.9.0-dev.20200409",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.0-dev.20200409.tgz",
-			"integrity": "sha512-S6rqgD9K1y3vva/2g6GSwtkg6RC8W74ssTq52NtpS/ujqptYOJIgWHnMK+QN9yjFk2fzJfH9/TIMeFnLkZyHZg==",
+			"version": "3.8.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+			"integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
 			"dev": true
 		},
 		"underscore": {

--- a/packages/web3-eth/package.json
+++ b/packages/web3-eth/package.json
@@ -9,7 +9,7 @@
     },
     "types": "types/index.d.ts",
     "scripts": {
-        "dtslint": "dtslint types"
+        "dtslint": "dtslint --localTs node_modules/typescript/lib  types"
     },
     "main": "src/index.js",
     "dependencies": {
@@ -28,7 +28,7 @@
         "web3-utils": "1.2.6"
     },
     "devDependencies": {
-        "definitelytyped-header-parser": "^3.9.0",
-        "dtslint": "^3.4.1"
+        "dtslint": "^3.4.1",
+        "typescript": "latest"
     }
 }

--- a/packages/web3-eth/types/index.d.ts
+++ b/packages/web3-eth/types/index.d.ts
@@ -19,8 +19,6 @@
  * @date 2018
  */
 
-// Minimum TypeScript Version: 3.0
-
 import * as net from 'net';
 import {
     BatchRequest,

--- a/packages/web3-net/package-lock.json
+++ b/packages/web3-net/package-lock.json
@@ -214,16 +214,6 @@
 			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
 			"dev": true
 		},
-		"definitelytyped-header-parser": {
-			"version": "3.9.0",
-			"resolved": "https://registry.npmjs.org/definitelytyped-header-parser/-/definitelytyped-header-parser-3.9.0.tgz",
-			"integrity": "sha512-slbwZ5h5lasB12t+9EAGYr060aCMqEXp6cwD7CoTriK40HNDYU56/XQ6S4sbjBK8ReGRMnB/uDx0elKkb4kuQA==",
-			"dev": true,
-			"requires": {
-				"@types/parsimmon": "^1.3.0",
-				"parsimmon": "^1.2.0"
-			}
-		},
 		"diff": {
 			"version": "3.5.0",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
@@ -293,7 +283,6 @@
 				"json-stable-stringify": "^1.0.1",
 				"strip-json-comments": "^2.0.1",
 				"tslint": "5.14.0",
-				"typescript": "^3.9.0-dev.20200409",
 				"yargs": "^15.1.0"
 			},
 			"dependencies": {
@@ -306,6 +295,11 @@
 						"@types/parsimmon": "^1.3.0",
 						"parsimmon": "^1.2.0"
 					}
+				},
+				"typescript": {
+					"version": "3.9.0-dev.20200417",
+					"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.0-dev.20200417.tgz",
+					"integrity": "sha512-VjLaL/mz6HfZb76uFyxcMrT2HriDQErE28rC5g7owTmKGHnwl56OauZIIYqL0wQk6JkWCb54XC+oio3CQ1rHyA=="
 				}
 			}
 		},
@@ -855,9 +849,9 @@
 			}
 		},
 		"typescript": {
-			"version": "3.9.0-dev.20200409",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.0-dev.20200409.tgz",
-			"integrity": "sha512-S6rqgD9K1y3vva/2g6GSwtkg6RC8W74ssTq52NtpS/ujqptYOJIgWHnMK+QN9yjFk2fzJfH9/TIMeFnLkZyHZg==",
+			"version": "3.8.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+			"integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
 			"dev": true
 		},
 		"universalify": {

--- a/packages/web3-net/package.json
+++ b/packages/web3-net/package.json
@@ -9,7 +9,7 @@
     },
     "types": "types/index.d.ts",
     "scripts": {
-        "dtslint": "dtslint types"
+        "dtslint": "dtslint --localTs node_modules/typescript/lib types"
     },
     "main": "src/index.js",
     "dependencies": {
@@ -18,7 +18,7 @@
         "web3-utils": "1.2.6"
     },
     "devDependencies": {
-        "definitelytyped-header-parser": "^3.9.0",
-        "dtslint": "^3.4.1"
+        "dtslint": "^3.4.1",
+        "typescript": "latest"
     }
 }

--- a/packages/web3-net/types/index.d.ts
+++ b/packages/web3-net/types/index.d.ts
@@ -17,8 +17,6 @@
  * @date 2018
  */
 
-// Minimum TypeScript Version: 3.0
-
 import { NetworkBase } from 'web3-core';
 
 export class Network extends NetworkBase {}

--- a/packages/web3-providers-http/package-lock.json
+++ b/packages/web3-providers-http/package-lock.json
@@ -219,16 +219,6 @@
 			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
 			"dev": true
 		},
-		"definitelytyped-header-parser": {
-			"version": "3.9.0",
-			"resolved": "https://registry.npmjs.org/definitelytyped-header-parser/-/definitelytyped-header-parser-3.9.0.tgz",
-			"integrity": "sha512-slbwZ5h5lasB12t+9EAGYr060aCMqEXp6cwD7CoTriK40HNDYU56/XQ6S4sbjBK8ReGRMnB/uDx0elKkb4kuQA==",
-			"dev": true,
-			"requires": {
-				"@types/parsimmon": "^1.3.0",
-				"parsimmon": "^1.2.0"
-			}
-		},
 		"diff": {
 			"version": "3.5.0",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
@@ -298,7 +288,6 @@
 				"json-stable-stringify": "^1.0.1",
 				"strip-json-comments": "^2.0.1",
 				"tslint": "5.14.0",
-				"typescript": "^3.9.0-dev.20200409",
 				"yargs": "^15.1.0"
 			},
 			"dependencies": {
@@ -311,6 +300,11 @@
 						"@types/parsimmon": "^1.3.0",
 						"parsimmon": "^1.2.0"
 					}
+				},
+				"typescript": {
+					"version": "3.9.0-dev.20200417",
+					"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.0-dev.20200417.tgz",
+					"integrity": "sha512-VjLaL/mz6HfZb76uFyxcMrT2HriDQErE28rC5g7owTmKGHnwl56OauZIIYqL0wQk6JkWCb54XC+oio3CQ1rHyA=="
 				}
 			}
 		},
@@ -860,9 +854,9 @@
 			}
 		},
 		"typescript": {
-			"version": "3.9.0-dev.20200409",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.0-dev.20200409.tgz",
-			"integrity": "sha512-S6rqgD9K1y3vva/2g6GSwtkg6RC8W74ssTq52NtpS/ujqptYOJIgWHnMK+QN9yjFk2fzJfH9/TIMeFnLkZyHZg==",
+			"version": "3.8.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+			"integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
 			"dev": true
 		},
 		"universalify": {

--- a/packages/web3-providers-http/package.json
+++ b/packages/web3-providers-http/package.json
@@ -8,7 +8,7 @@
         "node": ">=8.0.0"
     },
     "scripts": {
-        "dtslint": "dtslint types"
+        "dtslint": "dtslint --localTs node_modules/typescript/lib types"
     },
     "types": "types/index.d.ts",
     "main": "src/index.js",
@@ -17,7 +17,7 @@
         "xhr2-cookies": "1.1.0"
     },
     "devDependencies": {
-        "definitelytyped-header-parser": "^3.9.0",
-        "dtslint": "^3.4.1"
+        "dtslint": "^3.4.1",
+        "typescript": "latest"
     }
 }

--- a/packages/web3-providers-http/types/index.d.ts
+++ b/packages/web3-providers-http/types/index.d.ts
@@ -20,8 +20,6 @@
  * @date 2018
  */
 
-// Minimum TypeScript Version: 3.0
-
 import { HttpProviderBase } from 'web3-core-helpers';
 
 export class HttpProvider extends HttpProviderBase {}

--- a/packages/web3-providers-ipc/package-lock.json
+++ b/packages/web3-providers-ipc/package-lock.json
@@ -220,16 +220,6 @@
 			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
 			"dev": true
 		},
-		"definitelytyped-header-parser": {
-			"version": "3.9.0",
-			"resolved": "https://registry.npmjs.org/definitelytyped-header-parser/-/definitelytyped-header-parser-3.9.0.tgz",
-			"integrity": "sha512-slbwZ5h5lasB12t+9EAGYr060aCMqEXp6cwD7CoTriK40HNDYU56/XQ6S4sbjBK8ReGRMnB/uDx0elKkb4kuQA==",
-			"dev": true,
-			"requires": {
-				"@types/parsimmon": "^1.3.0",
-				"parsimmon": "^1.2.0"
-			}
-		},
 		"diff": {
 			"version": "3.5.0",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
@@ -299,7 +289,6 @@
 				"json-stable-stringify": "^1.0.1",
 				"strip-json-comments": "^2.0.1",
 				"tslint": "5.14.0",
-				"typescript": "^3.9.0-dev.20200409",
 				"yargs": "^15.1.0"
 			},
 			"dependencies": {
@@ -312,6 +301,11 @@
 						"@types/parsimmon": "^1.3.0",
 						"parsimmon": "^1.2.0"
 					}
+				},
+				"typescript": {
+					"version": "3.9.0-dev.20200417",
+					"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.0-dev.20200417.tgz",
+					"integrity": "sha512-VjLaL/mz6HfZb76uFyxcMrT2HriDQErE28rC5g7owTmKGHnwl56OauZIIYqL0wQk6JkWCb54XC+oio3CQ1rHyA=="
 				}
 			}
 		},
@@ -874,9 +868,9 @@
 			}
 		},
 		"typescript": {
-			"version": "3.9.0-dev.20200409",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.0-dev.20200409.tgz",
-			"integrity": "sha512-S6rqgD9K1y3vva/2g6GSwtkg6RC8W74ssTq52NtpS/ujqptYOJIgWHnMK+QN9yjFk2fzJfH9/TIMeFnLkZyHZg==",
+			"version": "3.8.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+			"integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
 			"dev": true
 		},
 		"underscore": {

--- a/packages/web3-providers-ipc/package.json
+++ b/packages/web3-providers-ipc/package.json
@@ -8,7 +8,7 @@
         "node": ">=8.0.0"
     },
     "scripts": {
-        "dtslint": "dtslint types"
+        "dtslint": "dtslint --localTs node_modules/typescript/lib types"
     },
     "types": "types/index.d.ts",
     "main": "src/index.js",
@@ -19,7 +19,7 @@
     },
     "devDependencies": {
         "@types/node": "^12.12.5",
-        "definitelytyped-header-parser": "^3.9.0",
-        "dtslint": "^3.4.1"
+        "dtslint": "^3.4.1",
+        "typescript": "latest"
     }
 }

--- a/packages/web3-providers-ipc/types/index.d.ts
+++ b/packages/web3-providers-ipc/types/index.d.ts
@@ -20,8 +20,6 @@
  * @date 2018
  */
 
-// Minimum TypeScript Version: 3.0
-
 import { IpcProviderBase } from 'web3-core-helpers';
 
 export class IpcProvider extends IpcProviderBase { }

--- a/packages/web3-providers-ws/package-lock.json
+++ b/packages/web3-providers-ws/package-lock.json
@@ -243,16 +243,6 @@
 			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
 			"dev": true
 		},
-		"definitelytyped-header-parser": {
-			"version": "3.9.0",
-			"resolved": "https://registry.npmjs.org/definitelytyped-header-parser/-/definitelytyped-header-parser-3.9.0.tgz",
-			"integrity": "sha512-slbwZ5h5lasB12t+9EAGYr060aCMqEXp6cwD7CoTriK40HNDYU56/XQ6S4sbjBK8ReGRMnB/uDx0elKkb4kuQA==",
-			"dev": true,
-			"requires": {
-				"@types/parsimmon": "^1.3.0",
-				"parsimmon": "^1.2.0"
-			}
-		},
 		"diff": {
 			"version": "3.5.0",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
@@ -322,7 +312,6 @@
 				"json-stable-stringify": "^1.0.1",
 				"strip-json-comments": "^2.0.1",
 				"tslint": "5.14.0",
-				"typescript": "^3.9.0-dev.20200409",
 				"yargs": "^15.1.0"
 			},
 			"dependencies": {
@@ -335,6 +324,11 @@
 						"@types/parsimmon": "^1.3.0",
 						"parsimmon": "^1.2.0"
 					}
+				},
+				"typescript": {
+					"version": "3.9.0-dev.20200417",
+					"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.0-dev.20200417.tgz",
+					"integrity": "sha512-VjLaL/mz6HfZb76uFyxcMrT2HriDQErE28rC5g7owTmKGHnwl56OauZIIYqL0wQk6JkWCb54XC+oio3CQ1rHyA=="
 				}
 			}
 		},
@@ -966,9 +960,9 @@
 			}
 		},
 		"typescript": {
-			"version": "3.9.0-dev.20200409",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.0-dev.20200409.tgz",
-			"integrity": "sha512-S6rqgD9K1y3vva/2g6GSwtkg6RC8W74ssTq52NtpS/ujqptYOJIgWHnMK+QN9yjFk2fzJfH9/TIMeFnLkZyHZg==",
+			"version": "3.8.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+			"integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
 			"dev": true
 		},
 		"underscore": {

--- a/packages/web3-providers-ws/package.json
+++ b/packages/web3-providers-ws/package.json
@@ -8,7 +8,7 @@
     "node": ">=8.0.0"
   },
   "scripts": {
-    "dtslint": "dtslint types"
+    "dtslint": "dtslint --localTs node_modules/typescript/lib types"
   },
   "types": "types/index.d.ts",
   "main": "src/index.js",
@@ -19,7 +19,7 @@
     "web3-core-helpers": "1.2.6"
   },
   "devDependencies": {
-    "definitelytyped-header-parser": "^3.9.0",
-    "dtslint": "^3.4.1"
+    "dtslint": "^3.4.1",
+    "typescript": "latest"
   }
 }

--- a/packages/web3-providers-ws/types/index.d.ts
+++ b/packages/web3-providers-ws/types/index.d.ts
@@ -20,8 +20,6 @@
  * @date 2018
  */
 
-// Minimum TypeScript Version: 3.0
-
 import { WebsocketProviderBase } from 'web3-core-helpers';
 
 export class WebsocketProvider extends WebsocketProviderBase { }

--- a/packages/web3-shh/package-lock.json
+++ b/packages/web3-shh/package-lock.json
@@ -220,16 +220,6 @@
 			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
 			"dev": true
 		},
-		"definitelytyped-header-parser": {
-			"version": "3.9.0",
-			"resolved": "https://registry.npmjs.org/definitelytyped-header-parser/-/definitelytyped-header-parser-3.9.0.tgz",
-			"integrity": "sha512-slbwZ5h5lasB12t+9EAGYr060aCMqEXp6cwD7CoTriK40HNDYU56/XQ6S4sbjBK8ReGRMnB/uDx0elKkb4kuQA==",
-			"dev": true,
-			"requires": {
-				"@types/parsimmon": "^1.3.0",
-				"parsimmon": "^1.2.0"
-			}
-		},
 		"diff": {
 			"version": "3.5.0",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
@@ -299,7 +289,6 @@
 				"json-stable-stringify": "^1.0.1",
 				"strip-json-comments": "^2.0.1",
 				"tslint": "5.14.0",
-				"typescript": "^3.9.0-dev.20200409",
 				"yargs": "^15.1.0"
 			},
 			"dependencies": {
@@ -312,6 +301,11 @@
 						"@types/parsimmon": "^1.3.0",
 						"parsimmon": "^1.2.0"
 					}
+				},
+				"typescript": {
+					"version": "3.9.0-dev.20200417",
+					"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.0-dev.20200417.tgz",
+					"integrity": "sha512-VjLaL/mz6HfZb76uFyxcMrT2HriDQErE28rC5g7owTmKGHnwl56OauZIIYqL0wQk6JkWCb54XC+oio3CQ1rHyA=="
 				}
 			}
 		},
@@ -861,9 +855,9 @@
 			}
 		},
 		"typescript": {
-			"version": "3.9.0-dev.20200409",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.0-dev.20200409.tgz",
-			"integrity": "sha512-S6rqgD9K1y3vva/2g6GSwtkg6RC8W74ssTq52NtpS/ujqptYOJIgWHnMK+QN9yjFk2fzJfH9/TIMeFnLkZyHZg==",
+			"version": "3.8.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+			"integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
 			"dev": true
 		},
 		"universalify": {

--- a/packages/web3-shh/package.json
+++ b/packages/web3-shh/package.json
@@ -9,7 +9,7 @@
     },
     "types": "types/index.d.ts",
     "scripts": {
-        "dtslint": "dtslint types"
+        "dtslint": "dtslint --localTs node_modules/typescript/lib  types"
     },
     "main": "src/index.js",
     "dependencies": {
@@ -20,7 +20,7 @@
     },
     "devDependencies": {
         "@types/node": "^12.12.5",
-        "definitelytyped-header-parser": "^3.9.0",
-        "dtslint": "^3.4.1"
+        "dtslint": "^3.4.1",
+        "typescript": "latest"
     }
 }

--- a/packages/web3-shh/types/index.d.ts
+++ b/packages/web3-shh/types/index.d.ts
@@ -17,8 +17,6 @@
  * @date 2018
  */
 
-// Minimum TypeScript Version: 3.0
-
 import * as net from 'net';
 import { BatchRequest, provider, Providers, Extension } from 'web3-core';
 import { Network } from 'web3-net';

--- a/packages/web3-utils/package-lock.json
+++ b/packages/web3-utils/package-lock.json
@@ -1,1394 +1,1380 @@
 {
-	"name": "web3-utils",
-	"version": "1.2.6",
-	"lockfileVersion": 1,
-	"requires": true,
-	"dependencies": {
-		"@types/color-name": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
-			"integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
-			"dev": true
-		},
-		"@types/parsimmon": {
-			"version": "1.10.1",
-			"resolved": "https://registry.npmjs.org/@types/parsimmon/-/parsimmon-1.10.1.tgz",
-			"integrity": "sha512-MoF2IC9oGSgArJwlxdst4XsvWuoYfNUWtBw0kpnCi6K05kV+Ecl7siEeJ40tgCbI9uqEMGQL/NlPMRv6KVkY5Q==",
-			"dev": true
-		},
-		"ansi-regex": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-			"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-			"dev": true
-		},
-		"ansi-styles": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-			"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-			"dev": true
-		},
-		"argparse": {
-			"version": "1.0.10",
-			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-			"dev": true,
-			"requires": {
-				"sprintf-js": "~1.0.2"
-			}
-		},
-		"babel-code-frame": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-			"dev": true,
-			"requires": {
-				"chalk": "^1.1.3",
-				"esutils": "^2.0.2",
-				"js-tokens": "^3.0.2"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-					"dev": true
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^2.2.1",
-						"escape-string-regexp": "^1.0.2",
-						"has-ansi": "^2.0.0",
-						"strip-ansi": "^3.0.0",
-						"supports-color": "^2.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^2.0.0"
-					}
-				}
-			}
-		},
-		"balanced-match": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-			"dev": true
-		},
-		"bn.js": {
-			"version": "4.11.8",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-			"integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
-		},
-		"brace-expansion": {
-			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-			"dev": true,
-			"requires": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
-		"brorand": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-			"integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
-		},
-		"buffer-to-arraybuffer": {
-			"version": "0.0.5",
-			"resolved": "https://registry.npmjs.org/buffer-to-arraybuffer/-/buffer-to-arraybuffer-0.0.5.tgz",
-			"integrity": "sha1-YGSkD6dutDxyOrqe+PbhIW0QURo="
-		},
-		"builtin-modules": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
-			"dev": true
-		},
-		"camelcase": {
-			"version": "5.3.1",
-			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-			"dev": true
-		},
-		"chalk": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-			"dev": true,
-			"requires": {
-				"ansi-styles": "^3.2.1",
-				"escape-string-regexp": "^1.0.5",
-				"supports-color": "^5.3.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
-			}
-		},
-		"cliui": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
-			"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
-			"dev": true,
-			"requires": {
-				"string-width": "^2.1.1",
-				"strip-ansi": "^4.0.0",
-				"wrap-ansi": "^2.0.0"
-			}
-		},
-		"code-point-at": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-			"dev": true
-		},
-		"color-convert": {
-			"version": "1.9.3",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-			"dev": true,
-			"requires": {
-				"color-name": "1.1.3"
-			}
-		},
-		"color-name": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-			"dev": true
-		},
-		"command-exists": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.8.tgz",
-			"integrity": "sha512-PM54PkseWbiiD/mMsbvW351/u+dafwTJ0ye2qB60G1aGQP9j3xK2gmMDc+R34L3nDtx4qMCitXT75mkbkGJDLw==",
-			"dev": true
-		},
-		"commander": {
-			"version": "2.20.3",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-			"dev": true
-		},
-		"concat-map": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-			"dev": true
-		},
-		"cross-spawn": {
-			"version": "6.0.5",
-			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-			"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-			"dev": true,
-			"requires": {
-				"nice-try": "^1.0.4",
-				"path-key": "^2.0.1",
-				"semver": "^5.5.0",
-				"shebang-command": "^1.2.0",
-				"which": "^1.2.9"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-					"dev": true
-				}
-			}
-		},
-		"decamelize": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-			"dev": true
-		},
-		"decode-uri-component": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
-		},
-		"decompress-response": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
-			"integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
-			"requires": {
-				"mimic-response": "^1.0.0"
-			}
-		},
-		"definitelytyped-header-parser": {
-			"version": "3.9.0",
-			"resolved": "https://registry.npmjs.org/definitelytyped-header-parser/-/definitelytyped-header-parser-3.9.0.tgz",
-			"integrity": "sha512-slbwZ5h5lasB12t+9EAGYr060aCMqEXp6cwD7CoTriK40HNDYU56/XQ6S4sbjBK8ReGRMnB/uDx0elKkb4kuQA==",
-			"dev": true,
-			"requires": {
-				"@types/parsimmon": "^1.3.0",
-				"parsimmon": "^1.2.0"
-			}
-		},
-		"diff": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
-			"dev": true
-		},
-		"dom-walk": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
-			"integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg="
-		},
-		"dts-critic": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/dts-critic/-/dts-critic-3.0.1.tgz",
-			"integrity": "sha512-3y34qsytqwEgfoUcYwxVm9Lv54Q+MPEXCOtZpwhl4TNM1SN/yjolWXz7Xw2U0BQv/rGhIdM2ONNTaAxRfQdJ6g==",
-			"dev": true,
-			"requires": {
-				"command-exists": "^1.2.8",
-				"definitelytyped-header-parser": "^3.8.2",
-				"semver": "^6.2.0",
-				"typescript": "^3.7.5",
-				"yargs": "^12.0.5"
-			},
-			"dependencies": {
-				"definitelytyped-header-parser": {
-					"version": "3.9.0",
-					"resolved": "https://registry.npmjs.org/definitelytyped-header-parser/-/definitelytyped-header-parser-3.9.0.tgz",
-					"integrity": "sha512-slbwZ5h5lasB12t+9EAGYr060aCMqEXp6cwD7CoTriK40HNDYU56/XQ6S4sbjBK8ReGRMnB/uDx0elKkb4kuQA==",
-					"dev": true,
-					"requires": {
-						"@types/parsimmon": "^1.3.0",
-						"parsimmon": "^1.2.0"
-					}
-				},
-				"typescript": {
-					"version": "3.8.3",
-					"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
-					"integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
-					"dev": true
-				},
-				"yargs": {
-					"version": "12.0.5",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
-					"integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
-					"dev": true,
-					"requires": {
-						"cliui": "^4.0.0",
-						"decamelize": "^1.2.0",
-						"find-up": "^3.0.0",
-						"get-caller-file": "^1.0.1",
-						"os-locale": "^3.0.0",
-						"require-directory": "^2.1.1",
-						"require-main-filename": "^1.0.1",
-						"set-blocking": "^2.0.0",
-						"string-width": "^2.0.0",
-						"which-module": "^2.0.0",
-						"y18n": "^3.2.1 || ^4.0.0",
-						"yargs-parser": "^11.1.1"
-					}
-				}
-			}
-		},
-		"dtslint": {
-			"version": "3.4.1",
-			"resolved": "https://registry.npmjs.org/dtslint/-/dtslint-3.4.1.tgz",
-			"integrity": "sha512-gIFYwlAO8vY17zGMqdJ7x2DA2swrQsKCwrtX0TUP4A36dlXjdFpj6NWMWc1HW5mYkWOkQFHwTWMOdkP6DLsrfA==",
-			"dev": true,
-			"requires": {
-				"definitelytyped-header-parser": "3.9.0",
-				"dts-critic": "^3.0.0",
-				"fs-extra": "^6.0.1",
-				"json-stable-stringify": "^1.0.1",
-				"strip-json-comments": "^2.0.1",
-				"tslint": "5.14.0",
-				"typescript": "^3.9.0-dev.20200409",
-				"yargs": "^15.1.0"
-			},
-			"dependencies": {
-				"definitelytyped-header-parser": {
-					"version": "3.9.0",
-					"resolved": "https://registry.npmjs.org/definitelytyped-header-parser/-/definitelytyped-header-parser-3.9.0.tgz",
-					"integrity": "sha512-slbwZ5h5lasB12t+9EAGYr060aCMqEXp6cwD7CoTriK40HNDYU56/XQ6S4sbjBK8ReGRMnB/uDx0elKkb4kuQA==",
-					"dev": true,
-					"requires": {
-						"@types/parsimmon": "^1.3.0",
-						"parsimmon": "^1.2.0"
-					}
-				}
-			}
-		},
-		"elliptic": {
-			"version": "6.5.2",
-			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
-			"integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
-			"requires": {
-				"bn.js": "^4.4.0",
-				"brorand": "^1.0.1",
-				"hash.js": "^1.0.0",
-				"hmac-drbg": "^1.0.0",
-				"inherits": "^2.0.1",
-				"minimalistic-assert": "^1.0.0",
-				"minimalistic-crypto-utils": "^1.0.0"
-			}
-		},
-		"emoji-regex": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-			"dev": true
-		},
-		"end-of-stream": {
-			"version": "1.4.4",
-			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
-			"integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-			"dev": true,
-			"requires": {
-				"once": "^1.4.0"
-			}
-		},
-		"escape-string-regexp": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-			"dev": true
-		},
-		"esprima": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-			"dev": true
-		},
-		"esutils": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-			"dev": true
-		},
-		"eth-lib": {
-			"version": "0.2.7",
-			"resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
-			"integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
-			"requires": {
-				"bn.js": "^4.11.6",
-				"elliptic": "^6.4.0",
-				"xhr-request-promise": "^0.1.2"
-			}
-		},
-		"ethereum-bloom-filters": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/ethereum-bloom-filters/-/ethereum-bloom-filters-1.0.6.tgz",
-			"integrity": "sha512-dE9CGNzgOOsdh7msZirvv8qjHtnHpvBlKe2647kM8v+yeF71IRso55jpojemvHV+jMjr48irPWxMRaHuOWzAFA==",
-			"requires": {
-				"js-sha3": "^0.8.0"
-			}
-		},
-		"ethjs-unit": {
-			"version": "0.1.6",
-			"resolved": "https://registry.npmjs.org/ethjs-unit/-/ethjs-unit-0.1.6.tgz",
-			"integrity": "sha1-xmWSHkduh7ziqdWIpv4EBbLEFpk=",
-			"requires": {
-				"bn.js": "4.11.6",
-				"number-to-bn": "1.7.0"
-			},
-			"dependencies": {
-				"bn.js": {
-					"version": "4.11.6",
-					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-					"integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
-				}
-			}
-		},
-		"execa": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
-			"integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
-			"dev": true,
-			"requires": {
-				"cross-spawn": "^6.0.0",
-				"get-stream": "^4.0.0",
-				"is-stream": "^1.1.0",
-				"npm-run-path": "^2.0.0",
-				"p-finally": "^1.0.0",
-				"signal-exit": "^3.0.0",
-				"strip-eof": "^1.0.0"
-			}
-		},
-		"find-up": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-			"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-			"dev": true,
-			"requires": {
-				"locate-path": "^3.0.0"
-			}
-		},
-		"fs-extra": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-6.0.1.tgz",
-			"integrity": "sha512-GnyIkKhhzXZUWFCaJzvyDLEEgDkPfb4/TPvJCJVuS8MWZgoSsErf++QpiAlDnKFcqhRlm+tIOcencCjyJE6ZCA==",
-			"dev": true,
-			"requires": {
-				"graceful-fs": "^4.1.2",
-				"jsonfile": "^4.0.0",
-				"universalify": "^0.1.0"
-			}
-		},
-		"fs.realpath": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-			"dev": true
-		},
-		"get-caller-file": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-			"integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
-			"dev": true
-		},
-		"get-stream": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-			"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-			"dev": true,
-			"requires": {
-				"pump": "^3.0.0"
-			}
-		},
-		"glob": {
-			"version": "7.1.6",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-			"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-			"dev": true,
-			"requires": {
-				"fs.realpath": "^1.0.0",
-				"inflight": "^1.0.4",
-				"inherits": "2",
-				"minimatch": "^3.0.4",
-				"once": "^1.3.0",
-				"path-is-absolute": "^1.0.0"
-			}
-		},
-		"global": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
-			"integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
-			"requires": {
-				"min-document": "^2.19.0",
-				"process": "~0.5.1"
-			}
-		},
-		"graceful-fs": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
-			"integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
-			"dev": true
-		},
-		"has-ansi": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-			"dev": true,
-			"requires": {
-				"ansi-regex": "^2.0.0"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-					"dev": true
-				}
-			}
-		},
-		"has-flag": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-			"dev": true
-		},
-		"hash.js": {
-			"version": "1.1.7",
-			"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
-			"integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
-			"requires": {
-				"inherits": "^2.0.3",
-				"minimalistic-assert": "^1.0.1"
-			}
-		},
-		"hmac-drbg": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
-			"integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
-			"requires": {
-				"hash.js": "^1.0.3",
-				"minimalistic-assert": "^1.0.0",
-				"minimalistic-crypto-utils": "^1.0.1"
-			}
-		},
-		"inflight": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-			"dev": true,
-			"requires": {
-				"once": "^1.3.0",
-				"wrappy": "1"
-			}
-		},
-		"inherits": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-		},
-		"invert-kv": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
-			"integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
-			"dev": true
-		},
-		"is-fullwidth-code-point": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-			"dev": true
-		},
-		"is-function": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.1.tgz",
-			"integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU="
-		},
-		"is-hex-prefixed": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz",
-			"integrity": "sha1-fY035q135dEnFIkTxXPggtd39VQ="
-		},
-		"is-stream": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-			"dev": true
-		},
-		"isexe": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-			"dev": true
-		},
-		"js-sha3": {
-			"version": "0.8.0",
-			"resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-			"integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
-		},
-		"js-tokens": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-			"dev": true
-		},
-		"js-yaml": {
-			"version": "3.13.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-			"integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
-			"dev": true,
-			"requires": {
-				"argparse": "^1.0.7",
-				"esprima": "^4.0.0"
-			}
-		},
-		"json-stable-stringify": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-			"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-			"dev": true,
-			"requires": {
-				"jsonify": "~0.0.0"
-			}
-		},
-		"jsonfile": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-			"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-			"dev": true,
-			"requires": {
-				"graceful-fs": "^4.1.6"
-			}
-		},
-		"jsonify": {
-			"version": "0.0.0",
-			"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-			"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-			"dev": true
-		},
-		"lcid": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
-			"integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
-			"dev": true,
-			"requires": {
-				"invert-kv": "^2.0.0"
-			}
-		},
-		"locate-path": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-			"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-			"dev": true,
-			"requires": {
-				"p-locate": "^3.0.0",
-				"path-exists": "^3.0.0"
-			}
-		},
-		"map-age-cleaner": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
-			"integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
-			"dev": true,
-			"requires": {
-				"p-defer": "^1.0.0"
-			}
-		},
-		"mem": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
-			"integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
-			"dev": true,
-			"requires": {
-				"map-age-cleaner": "^0.1.1",
-				"mimic-fn": "^2.0.0",
-				"p-is-promise": "^2.0.0"
-			}
-		},
-		"mimic-fn": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-			"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-			"dev": true
-		},
-		"mimic-response": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-			"integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
-		},
-		"min-document": {
-			"version": "2.19.0",
-			"resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
-			"integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
-			"requires": {
-				"dom-walk": "^0.1.0"
-			}
-		},
-		"minimalistic-assert": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-			"integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
-		},
-		"minimalistic-crypto-utils": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-			"integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
-		},
-		"minimatch": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-			"dev": true,
-			"requires": {
-				"brace-expansion": "^1.1.7"
-			}
-		},
-		"minimist": {
-			"version": "1.2.5",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-			"dev": true
-		},
-		"mkdirp": {
-			"version": "0.5.5",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-			"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-			"dev": true,
-			"requires": {
-				"minimist": "^1.2.5"
-			}
-		},
-		"nice-try": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
-			"dev": true
-		},
-		"npm-run-path": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-			"dev": true,
-			"requires": {
-				"path-key": "^2.0.0"
-			}
-		},
-		"number-is-nan": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-			"dev": true
-		},
-		"number-to-bn": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.7.0.tgz",
-			"integrity": "sha1-uzYjWS9+X54AMLGXe9QaDFP+HqA=",
-			"requires": {
-				"bn.js": "4.11.6",
-				"strip-hex-prefix": "1.0.0"
-			},
-			"dependencies": {
-				"bn.js": {
-					"version": "4.11.6",
-					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-					"integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
-				}
-			}
-		},
-		"object-assign": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-		},
-		"once": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-			"requires": {
-				"wrappy": "1"
-			}
-		},
-		"os-locale": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
-			"integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
-			"dev": true,
-			"requires": {
-				"execa": "^1.0.0",
-				"lcid": "^2.0.0",
-				"mem": "^4.0.0"
-			}
-		},
-		"p-defer": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
-			"integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
-			"dev": true
-		},
-		"p-finally": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-			"dev": true
-		},
-		"p-is-promise": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
-			"integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
-			"dev": true
-		},
-		"p-limit": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-			"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-			"dev": true,
-			"requires": {
-				"p-try": "^2.0.0"
-			}
-		},
-		"p-locate": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-			"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-			"dev": true,
-			"requires": {
-				"p-limit": "^2.0.0"
-			}
-		},
-		"p-try": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-			"dev": true
-		},
-		"parse-headers": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.3.tgz",
-			"integrity": "sha512-QhhZ+DCCit2Coi2vmAKbq5RGTRcQUOE2+REgv8vdyu7MnYx2eZztegqtTx99TZ86GTIwqiy3+4nQTWZ2tgmdCA=="
-		},
-		"parsimmon": {
-			"version": "1.13.0",
-			"resolved": "https://registry.npmjs.org/parsimmon/-/parsimmon-1.13.0.tgz",
-			"integrity": "sha512-5UIrOCW+gjbILkjKPgTgmq8LKf8TT3Iy7kN2VD7OtQ81facKn8B4gG1X94jWqXYZsxG2KbJhrv/Yq/5H6BQn7A==",
-			"dev": true
-		},
-		"path-exists": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-			"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-			"dev": true
-		},
-		"path-is-absolute": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-			"dev": true
-		},
-		"path-key": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-			"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-			"dev": true
-		},
-		"path-parse": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
-			"dev": true
-		},
-		"process": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
-			"integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8="
-		},
-		"pump": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-			"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-			"dev": true,
-			"requires": {
-				"end-of-stream": "^1.1.0",
-				"once": "^1.3.1"
-			}
-		},
-		"query-string": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
-			"integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
-			"requires": {
-				"decode-uri-component": "^0.2.0",
-				"object-assign": "^4.1.0",
-				"strict-uri-encode": "^1.0.0"
-			}
-		},
-		"randombytes": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-			"requires": {
-				"safe-buffer": "^5.1.0"
-			}
-		},
-		"require-directory": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-			"dev": true
-		},
-		"require-main-filename": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
-			"dev": true
-		},
-		"resolve": {
-			"version": "1.15.1",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
-			"integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
-			"dev": true,
-			"requires": {
-				"path-parse": "^1.0.6"
-			}
-		},
-		"safe-buffer": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-			"integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
-		},
-		"semver": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-			"dev": true
-		},
-		"set-blocking": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-			"dev": true
-		},
-		"shebang-command": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-			"dev": true,
-			"requires": {
-				"shebang-regex": "^1.0.0"
-			}
-		},
-		"shebang-regex": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-			"dev": true
-		},
-		"signal-exit": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-			"integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
-			"dev": true
-		},
-		"simple-concat": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
-			"integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY="
-		},
-		"simple-get": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz",
-			"integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
-			"requires": {
-				"decompress-response": "^3.3.0",
-				"once": "^1.3.1",
-				"simple-concat": "^1.0.0"
-			}
-		},
-		"sprintf-js": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-			"dev": true
-		},
-		"strict-uri-encode": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
-			"integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
-		},
-		"string-width": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-			"dev": true,
-			"requires": {
-				"is-fullwidth-code-point": "^2.0.0",
-				"strip-ansi": "^4.0.0"
-			}
-		},
-		"strip-ansi": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-			"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-			"dev": true,
-			"requires": {
-				"ansi-regex": "^3.0.0"
-			}
-		},
-		"strip-eof": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
-			"dev": true
-		},
-		"strip-hex-prefix": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/strip-hex-prefix/-/strip-hex-prefix-1.0.0.tgz",
-			"integrity": "sha1-DF8VX+8RUTczd96du1iNoFUA428=",
-			"requires": {
-				"is-hex-prefixed": "1.0.0"
-			}
-		},
-		"strip-json-comments": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-			"dev": true
-		},
-		"supports-color": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-			"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-			"dev": true
-		},
-		"timed-out": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
-			"integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
-		},
-		"tslib": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
-			"integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==",
-			"dev": true
-		},
-		"tslint": {
-			"version": "5.14.0",
-			"resolved": "https://registry.npmjs.org/tslint/-/tslint-5.14.0.tgz",
-			"integrity": "sha512-IUla/ieHVnB8Le7LdQFRGlVJid2T/gaJe5VkjzRVSRR6pA2ODYrnfR1hmxi+5+au9l50jBwpbBL34txgv4NnTQ==",
-			"dev": true,
-			"requires": {
-				"babel-code-frame": "^6.22.0",
-				"builtin-modules": "^1.1.1",
-				"chalk": "^2.3.0",
-				"commander": "^2.12.1",
-				"diff": "^3.2.0",
-				"glob": "^7.1.1",
-				"js-yaml": "^3.7.0",
-				"minimatch": "^3.0.4",
-				"mkdirp": "^0.5.1",
-				"resolve": "^1.3.2",
-				"semver": "^5.3.0",
-				"tslib": "^1.8.0",
-				"tsutils": "^2.29.0"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-					"dev": true
-				}
-			}
-		},
-		"tsutils": {
-			"version": "2.29.0",
-			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
-			"integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
-			"dev": true,
-			"requires": {
-				"tslib": "^1.8.1"
-			}
-		},
-		"typescript": {
-			"version": "3.9.0-dev.20200409",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.0-dev.20200409.tgz",
-			"integrity": "sha512-S6rqgD9K1y3vva/2g6GSwtkg6RC8W74ssTq52NtpS/ujqptYOJIgWHnMK+QN9yjFk2fzJfH9/TIMeFnLkZyHZg==",
-			"dev": true
-		},
-		"underscore": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
-			"integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
-		},
-		"universalify": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-			"dev": true
-		},
-		"url-set-query": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/url-set-query/-/url-set-query-1.0.0.tgz",
-			"integrity": "sha1-AW6M/Xwg7gXK/neV6JK9BwL6ozk="
-		},
-		"utf8": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
-			"integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ=="
-		},
-		"which": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-			"dev": true,
-			"requires": {
-				"isexe": "^2.0.0"
-			}
-		},
-		"which-module": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-			"dev": true
-		},
-		"wrap-ansi": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-			"dev": true,
-			"requires": {
-				"string-width": "^1.0.1",
-				"strip-ansi": "^3.0.1"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-					"dev": true
-				},
-				"is-fullwidth-code-point": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"dev": true,
-					"requires": {
-						"number-is-nan": "^1.0.0"
-					}
-				},
-				"string-width": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"dev": true,
-					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^2.0.0"
-					}
-				}
-			}
-		},
-		"wrappy": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-		},
-		"xhr": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/xhr/-/xhr-2.5.0.tgz",
-			"integrity": "sha512-4nlO/14t3BNUZRXIXfXe+3N6w3s1KoxcJUUURctd64BLRe67E4gRwp4PjywtDY72fXpZ1y6Ch0VZQRY/gMPzzQ==",
-			"requires": {
-				"global": "~4.3.0",
-				"is-function": "^1.0.1",
-				"parse-headers": "^2.0.0",
-				"xtend": "^4.0.0"
-			}
-		},
-		"xhr-request": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/xhr-request/-/xhr-request-1.1.0.tgz",
-			"integrity": "sha512-Y7qzEaR3FDtL3fP30k9wO/e+FBnBByZeybKOhASsGP30NIkRAAkKD/sCnLvgEfAIEC1rcmK7YG8f4oEnIrrWzA==",
-			"requires": {
-				"buffer-to-arraybuffer": "^0.0.5",
-				"object-assign": "^4.1.1",
-				"query-string": "^5.0.1",
-				"simple-get": "^2.7.0",
-				"timed-out": "^4.0.1",
-				"url-set-query": "^1.0.0",
-				"xhr": "^2.0.4"
-			}
-		},
-		"xhr-request-promise": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/xhr-request-promise/-/xhr-request-promise-0.1.2.tgz",
-			"integrity": "sha1-NDxE0e53JrhkgGloLQ+EDIO0Jh0=",
-			"requires": {
-				"xhr-request": "^1.0.1"
-			}
-		},
-		"xtend": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-			"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
-		},
-		"y18n": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-			"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
-			"dev": true
-		},
-		"yargs": {
-			"version": "15.3.1",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.3.1.tgz",
-			"integrity": "sha512-92O1HWEjw27sBfgmXiixJWT5hRBp2eobqXicLtPBIDBhYB+1HpwZlXmbW2luivBJHBzki+7VyCLRtAkScbTBQA==",
-			"dev": true,
-			"requires": {
-				"cliui": "^6.0.0",
-				"decamelize": "^1.2.0",
-				"find-up": "^4.1.0",
-				"get-caller-file": "^2.0.1",
-				"require-directory": "^2.1.1",
-				"require-main-filename": "^2.0.0",
-				"set-blocking": "^2.0.0",
-				"string-width": "^4.2.0",
-				"which-module": "^2.0.0",
-				"y18n": "^4.0.0",
-				"yargs-parser": "^18.1.1"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-					"dev": true
-				},
-				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-					"dev": true,
-					"requires": {
-						"@types/color-name": "^1.1.1",
-						"color-convert": "^2.0.1"
-					}
-				},
-				"cliui": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-					"integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
-					"dev": true,
-					"requires": {
-						"string-width": "^4.2.0",
-						"strip-ansi": "^6.0.0",
-						"wrap-ansi": "^6.2.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				},
-				"find-up": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-					"dev": true,
-					"requires": {
-						"locate-path": "^5.0.0",
-						"path-exists": "^4.0.0"
-					}
-				},
-				"get-caller-file": {
-					"version": "2.0.5",
-					"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-					"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-					"dev": true
-				},
-				"is-fullwidth-code-point": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-					"dev": true
-				},
-				"locate-path": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-					"dev": true,
-					"requires": {
-						"p-locate": "^4.1.0"
-					}
-				},
-				"p-locate": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-					"dev": true,
-					"requires": {
-						"p-limit": "^2.2.0"
-					}
-				},
-				"path-exists": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-					"dev": true
-				},
-				"require-main-filename": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-					"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-					"dev": true
-				},
-				"string-width": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-					"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
-					"dev": true,
-					"requires": {
-						"emoji-regex": "^8.0.0",
-						"is-fullwidth-code-point": "^3.0.0",
-						"strip-ansi": "^6.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^5.0.0"
-					}
-				},
-				"wrap-ansi": {
-					"version": "6.2.0",
-					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-					"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.0.0",
-						"string-width": "^4.1.0",
-						"strip-ansi": "^6.0.0"
-					}
-				},
-				"yargs-parser": {
-					"version": "18.1.2",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.2.tgz",
-					"integrity": "sha512-hlIPNR3IzC1YuL1c2UwwDKpXlNFBqD1Fswwh1khz5+d8Cq/8yc/Mn0i+rQXduu8hcrFKvO7Eryk+09NecTQAAQ==",
-					"dev": true,
-					"requires": {
-						"camelcase": "^5.0.0",
-						"decamelize": "^1.2.0"
-					}
-				}
-			}
-		},
-		"yargs-parser": {
-			"version": "11.1.1",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
-			"integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
-			"dev": true,
-			"requires": {
-				"camelcase": "^5.0.0",
-				"decamelize": "^1.2.0"
-			}
-		}
-	}
+    "name": "web3-utils",
+    "version": "1.2.6",
+    "lockfileVersion": 1,
+    "requires": true,
+    "dependencies": {
+        "@types/color-name": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+            "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
+            "dev": true
+        },
+        "@types/parsimmon": {
+            "version": "1.10.1",
+            "resolved": "https://registry.npmjs.org/@types/parsimmon/-/parsimmon-1.10.1.tgz",
+            "integrity": "sha512-MoF2IC9oGSgArJwlxdst4XsvWuoYfNUWtBw0kpnCi6K05kV+Ecl7siEeJ40tgCbI9uqEMGQL/NlPMRv6KVkY5Q==",
+            "dev": true
+        },
+        "ansi-regex": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+            "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+            "dev": true
+        },
+        "ansi-styles": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+            "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+            "dev": true
+        },
+        "argparse": {
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+            "dev": true,
+            "requires": {
+                "sprintf-js": "~1.0.2"
+            }
+        },
+        "babel-code-frame": {
+            "version": "6.26.0",
+            "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+            "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+            "dev": true,
+            "requires": {
+                "chalk": "^1.1.3",
+                "esutils": "^2.0.2",
+                "js-tokens": "^3.0.2"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+                    "dev": true
+                },
+                "chalk": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^2.0.0"
+                    }
+                }
+            }
+        },
+        "balanced-match": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+            "dev": true
+        },
+        "bn.js": {
+            "version": "4.11.8",
+            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+            "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+        },
+        "brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dev": true,
+            "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "brorand": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+            "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
+        },
+        "buffer-to-arraybuffer": {
+            "version": "0.0.5",
+            "resolved": "https://registry.npmjs.org/buffer-to-arraybuffer/-/buffer-to-arraybuffer-0.0.5.tgz",
+            "integrity": "sha1-YGSkD6dutDxyOrqe+PbhIW0QURo="
+        },
+        "builtin-modules": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+            "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+            "dev": true
+        },
+        "camelcase": {
+            "version": "5.3.1",
+            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+            "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+            "dev": true
+        },
+        "chalk": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+            "dev": true,
+            "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "cliui": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+            "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+            "dev": true,
+            "requires": {
+                "string-width": "^2.1.1",
+                "strip-ansi": "^4.0.0",
+                "wrap-ansi": "^2.0.0"
+            }
+        },
+        "code-point-at": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+            "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+            "dev": true
+        },
+        "color-convert": {
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+            "dev": true,
+            "requires": {
+                "color-name": "1.1.3"
+            }
+        },
+        "color-name": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+            "dev": true
+        },
+        "command-exists": {
+            "version": "1.2.9",
+            "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
+            "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w==",
+            "dev": true
+        },
+        "commander": {
+            "version": "2.20.3",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+            "dev": true
+        },
+        "concat-map": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+            "dev": true
+        },
+        "cross-spawn": {
+            "version": "6.0.5",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+            "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+            "dev": true,
+            "requires": {
+                "nice-try": "^1.0.4",
+                "path-key": "^2.0.1",
+                "semver": "^5.5.0",
+                "shebang-command": "^1.2.0",
+                "which": "^1.2.9"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "5.7.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+                    "dev": true
+                }
+            }
+        },
+        "decamelize": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+            "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+            "dev": true
+        },
+        "decode-uri-component": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+            "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+        },
+        "decompress-response": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+            "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+            "requires": {
+                "mimic-response": "^1.0.0"
+            }
+        },
+        "definitelytyped-header-parser": {
+            "version": "3.9.0",
+            "resolved": "https://registry.npmjs.org/definitelytyped-header-parser/-/definitelytyped-header-parser-3.9.0.tgz",
+            "integrity": "sha512-slbwZ5h5lasB12t+9EAGYr060aCMqEXp6cwD7CoTriK40HNDYU56/XQ6S4sbjBK8ReGRMnB/uDx0elKkb4kuQA==",
+            "dev": true,
+            "requires": {
+                "@types/parsimmon": "^1.3.0",
+                "parsimmon": "^1.2.0"
+            }
+        },
+        "diff": {
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+            "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+            "dev": true
+        },
+        "dom-walk": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
+            "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
+        },
+        "dts-critic": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/dts-critic/-/dts-critic-3.0.1.tgz",
+            "integrity": "sha512-3y34qsytqwEgfoUcYwxVm9Lv54Q+MPEXCOtZpwhl4TNM1SN/yjolWXz7Xw2U0BQv/rGhIdM2ONNTaAxRfQdJ6g==",
+            "dev": true,
+            "requires": {
+                "command-exists": "^1.2.8",
+                "definitelytyped-header-parser": "^3.8.2",
+                "semver": "^6.2.0",
+                "typescript": "^3.7.5",
+                "yargs": "^12.0.5"
+            },
+            "dependencies": {
+                "typescript": {
+                    "version": "3.8.3",
+                    "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+                    "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
+                    "dev": true
+                },
+                "yargs": {
+                    "version": "12.0.5",
+                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
+                    "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
+                    "dev": true,
+                    "requires": {
+                        "cliui": "^4.0.0",
+                        "decamelize": "^1.2.0",
+                        "find-up": "^3.0.0",
+                        "get-caller-file": "^1.0.1",
+                        "os-locale": "^3.0.0",
+                        "require-directory": "^2.1.1",
+                        "require-main-filename": "^1.0.1",
+                        "set-blocking": "^2.0.0",
+                        "string-width": "^2.0.0",
+                        "which-module": "^2.0.0",
+                        "y18n": "^3.2.1 || ^4.0.0",
+                        "yargs-parser": "^11.1.1"
+                    }
+                }
+            }
+        },
+        "dtslint": {
+            "version": "3.4.1",
+            "resolved": "https://registry.npmjs.org/dtslint/-/dtslint-3.4.1.tgz",
+            "integrity": "sha512-gIFYwlAO8vY17zGMqdJ7x2DA2swrQsKCwrtX0TUP4A36dlXjdFpj6NWMWc1HW5mYkWOkQFHwTWMOdkP6DLsrfA==",
+            "dev": true,
+            "requires": {
+                "definitelytyped-header-parser": "3.9.0",
+                "dts-critic": "^3.0.0",
+                "fs-extra": "^6.0.1",
+                "json-stable-stringify": "^1.0.1",
+                "strip-json-comments": "^2.0.1",
+                "tslint": "5.14.0",
+                "typescript": "^3.9.0-dev.20200417",
+                "yargs": "^15.1.0"
+            },
+            "dependencies": {
+                "typescript": {
+                    "version": "3.9.0-dev.20200417",
+                    "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.0-dev.20200417.tgz",
+                    "integrity": "sha512-VjLaL/mz6HfZb76uFyxcMrT2HriDQErE28rC5g7owTmKGHnwl56OauZIIYqL0wQk6JkWCb54XC+oio3CQ1rHyA==",
+                    "dev": true
+                }
+            }
+        },
+        "elliptic": {
+            "version": "6.5.2",
+            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
+            "integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
+            "requires": {
+                "bn.js": "^4.4.0",
+                "brorand": "^1.0.1",
+                "hash.js": "^1.0.0",
+                "hmac-drbg": "^1.0.0",
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0",
+                "minimalistic-crypto-utils": "^1.0.0"
+            }
+        },
+        "emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "dev": true
+        },
+        "end-of-stream": {
+            "version": "1.4.4",
+            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+            "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+            "dev": true,
+            "requires": {
+                "once": "^1.4.0"
+            }
+        },
+        "escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+            "dev": true
+        },
+        "esprima": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+            "dev": true
+        },
+        "esutils": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+            "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+            "dev": true
+        },
+        "eth-lib": {
+            "version": "0.2.7",
+            "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+            "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+            "requires": {
+                "bn.js": "^4.11.6",
+                "elliptic": "^6.4.0",
+                "xhr-request-promise": "^0.1.2"
+            }
+        },
+        "ethereum-bloom-filters": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/ethereum-bloom-filters/-/ethereum-bloom-filters-1.0.7.tgz",
+            "integrity": "sha512-cDcJJSJ9GMAcURiAWO3DxIEhTL/uWqlQnvgKpuYQzYPrt/izuGU+1ntQmHt0IRq6ADoSYHFnB+aCEFIldjhkMQ==",
+            "requires": {
+                "js-sha3": "^0.8.0"
+            }
+        },
+        "ethjs-unit": {
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/ethjs-unit/-/ethjs-unit-0.1.6.tgz",
+            "integrity": "sha1-xmWSHkduh7ziqdWIpv4EBbLEFpk=",
+            "requires": {
+                "bn.js": "4.11.6",
+                "number-to-bn": "1.7.0"
+            },
+            "dependencies": {
+                "bn.js": {
+                    "version": "4.11.6",
+                    "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+                    "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+                }
+            }
+        },
+        "execa": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+            "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+            "dev": true,
+            "requires": {
+                "cross-spawn": "^6.0.0",
+                "get-stream": "^4.0.0",
+                "is-stream": "^1.1.0",
+                "npm-run-path": "^2.0.0",
+                "p-finally": "^1.0.0",
+                "signal-exit": "^3.0.0",
+                "strip-eof": "^1.0.0"
+            }
+        },
+        "find-up": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+            "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+            "dev": true,
+            "requires": {
+                "locate-path": "^3.0.0"
+            }
+        },
+        "fs-extra": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-6.0.1.tgz",
+            "integrity": "sha512-GnyIkKhhzXZUWFCaJzvyDLEEgDkPfb4/TPvJCJVuS8MWZgoSsErf++QpiAlDnKFcqhRlm+tIOcencCjyJE6ZCA==",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.2",
+                "jsonfile": "^4.0.0",
+                "universalify": "^0.1.0"
+            }
+        },
+        "fs.realpath": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+            "dev": true
+        },
+        "get-caller-file": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+            "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+            "dev": true
+        },
+        "get-stream": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+            "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+            "dev": true,
+            "requires": {
+                "pump": "^3.0.0"
+            }
+        },
+        "glob": {
+            "version": "7.1.6",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+            "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+            "dev": true,
+            "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            }
+        },
+        "global": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
+            "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
+            "requires": {
+                "min-document": "^2.19.0",
+                "process": "~0.5.1"
+            }
+        },
+        "graceful-fs": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
+            "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
+            "dev": true
+        },
+        "has-ansi": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+            "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+            "dev": true,
+            "requires": {
+                "ansi-regex": "^2.0.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+                    "dev": true
+                }
+            }
+        },
+        "has-flag": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+            "dev": true
+        },
+        "hash.js": {
+            "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+            "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+            "requires": {
+                "inherits": "^2.0.3",
+                "minimalistic-assert": "^1.0.1"
+            }
+        },
+        "hmac-drbg": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+            "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+            "requires": {
+                "hash.js": "^1.0.3",
+                "minimalistic-assert": "^1.0.0",
+                "minimalistic-crypto-utils": "^1.0.1"
+            }
+        },
+        "inflight": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+            "dev": true,
+            "requires": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+            }
+        },
+        "inherits": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+        },
+        "invert-kv": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+            "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
+            "dev": true
+        },
+        "is-fullwidth-code-point": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+            "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+            "dev": true
+        },
+        "is-function": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.1.tgz",
+            "integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU="
+        },
+        "is-hex-prefixed": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz",
+            "integrity": "sha1-fY035q135dEnFIkTxXPggtd39VQ="
+        },
+        "is-stream": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+            "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+            "dev": true
+        },
+        "isexe": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+            "dev": true
+        },
+        "js-sha3": {
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+            "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
+        },
+        "js-tokens": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+            "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+            "dev": true
+        },
+        "js-yaml": {
+            "version": "3.13.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+            "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+            "dev": true,
+            "requires": {
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
+            }
+        },
+        "json-stable-stringify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+            "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+            "dev": true,
+            "requires": {
+                "jsonify": "~0.0.0"
+            }
+        },
+        "jsonfile": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+            "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.6"
+            }
+        },
+        "jsonify": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+            "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+            "dev": true
+        },
+        "lcid": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+            "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
+            "dev": true,
+            "requires": {
+                "invert-kv": "^2.0.0"
+            }
+        },
+        "locate-path": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+            "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+            "dev": true,
+            "requires": {
+                "p-locate": "^3.0.0",
+                "path-exists": "^3.0.0"
+            }
+        },
+        "map-age-cleaner": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+            "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
+            "dev": true,
+            "requires": {
+                "p-defer": "^1.0.0"
+            }
+        },
+        "mem": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
+            "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
+            "dev": true,
+            "requires": {
+                "map-age-cleaner": "^0.1.1",
+                "mimic-fn": "^2.0.0",
+                "p-is-promise": "^2.0.0"
+            }
+        },
+        "mimic-fn": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+            "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+            "dev": true
+        },
+        "mimic-response": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+            "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
+        },
+        "min-document": {
+            "version": "2.19.0",
+            "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
+            "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
+            "requires": {
+                "dom-walk": "^0.1.0"
+            }
+        },
+        "minimalistic-assert": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+            "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+        },
+        "minimalistic-crypto-utils": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+            "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
+        },
+        "minimatch": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "dev": true,
+            "requires": {
+                "brace-expansion": "^1.1.7"
+            }
+        },
+        "minimist": {
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+            "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+            "dev": true
+        },
+        "mkdirp": {
+            "version": "0.5.5",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+            "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+            "dev": true,
+            "requires": {
+                "minimist": "^1.2.5"
+            }
+        },
+        "nice-try": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+            "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+            "dev": true
+        },
+        "npm-run-path": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+            "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+            "dev": true,
+            "requires": {
+                "path-key": "^2.0.0"
+            }
+        },
+        "number-is-nan": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+            "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+            "dev": true
+        },
+        "number-to-bn": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.7.0.tgz",
+            "integrity": "sha1-uzYjWS9+X54AMLGXe9QaDFP+HqA=",
+            "requires": {
+                "bn.js": "4.11.6",
+                "strip-hex-prefix": "1.0.0"
+            },
+            "dependencies": {
+                "bn.js": {
+                    "version": "4.11.6",
+                    "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+                    "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+                }
+            }
+        },
+        "object-assign": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+        },
+        "once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "requires": {
+                "wrappy": "1"
+            }
+        },
+        "os-locale": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+            "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
+            "dev": true,
+            "requires": {
+                "execa": "^1.0.0",
+                "lcid": "^2.0.0",
+                "mem": "^4.0.0"
+            }
+        },
+        "p-defer": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+            "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
+            "dev": true
+        },
+        "p-finally": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+            "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+            "dev": true
+        },
+        "p-is-promise": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
+            "integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
+            "dev": true
+        },
+        "p-limit": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+            "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+            "dev": true,
+            "requires": {
+                "p-try": "^2.0.0"
+            }
+        },
+        "p-locate": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+            "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+            "dev": true,
+            "requires": {
+                "p-limit": "^2.0.0"
+            }
+        },
+        "p-try": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+            "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+            "dev": true
+        },
+        "parse-headers": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.3.tgz",
+            "integrity": "sha512-QhhZ+DCCit2Coi2vmAKbq5RGTRcQUOE2+REgv8vdyu7MnYx2eZztegqtTx99TZ86GTIwqiy3+4nQTWZ2tgmdCA=="
+        },
+        "parsimmon": {
+            "version": "1.13.0",
+            "resolved": "https://registry.npmjs.org/parsimmon/-/parsimmon-1.13.0.tgz",
+            "integrity": "sha512-5UIrOCW+gjbILkjKPgTgmq8LKf8TT3Iy7kN2VD7OtQ81facKn8B4gG1X94jWqXYZsxG2KbJhrv/Yq/5H6BQn7A==",
+            "dev": true
+        },
+        "path-exists": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+            "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+            "dev": true
+        },
+        "path-is-absolute": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+            "dev": true
+        },
+        "path-key": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+            "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+            "dev": true
+        },
+        "path-parse": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+            "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+            "dev": true
+        },
+        "process": {
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
+            "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8="
+        },
+        "pump": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+            "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+            "dev": true,
+            "requires": {
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
+            }
+        },
+        "query-string": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
+            "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
+            "requires": {
+                "decode-uri-component": "^0.2.0",
+                "object-assign": "^4.1.0",
+                "strict-uri-encode": "^1.0.0"
+            }
+        },
+        "randombytes": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+            "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+            "requires": {
+                "safe-buffer": "^5.1.0"
+            }
+        },
+        "require-directory": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+            "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+            "dev": true
+        },
+        "require-main-filename": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+            "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+            "dev": true
+        },
+        "resolve": {
+            "version": "1.16.0",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.16.0.tgz",
+            "integrity": "sha512-LarL/PIKJvc09k1jaeT4kQb/8/7P+qV4qSnN2K80AES+OHdfZELAKVOBjxsvtToT/uLOfFbvYvKfZmV8cee7nA==",
+            "dev": true,
+            "requires": {
+                "path-parse": "^1.0.6"
+            }
+        },
+        "safe-buffer": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+            "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+        },
+        "semver": {
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+            "dev": true
+        },
+        "set-blocking": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+            "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+            "dev": true
+        },
+        "shebang-command": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+            "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+            "dev": true,
+            "requires": {
+                "shebang-regex": "^1.0.0"
+            }
+        },
+        "shebang-regex": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+            "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+            "dev": true
+        },
+        "signal-exit": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
+            "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
+            "dev": true
+        },
+        "simple-concat": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
+            "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY="
+        },
+        "simple-get": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz",
+            "integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
+            "requires": {
+                "decompress-response": "^3.3.0",
+                "once": "^1.3.1",
+                "simple-concat": "^1.0.0"
+            }
+        },
+        "sprintf-js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+            "dev": true
+        },
+        "strict-uri-encode": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+            "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
+        },
+        "string-width": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+            "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+            "dev": true,
+            "requires": {
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
+            }
+        },
+        "strip-ansi": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+            "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+            "dev": true,
+            "requires": {
+                "ansi-regex": "^3.0.0"
+            }
+        },
+        "strip-eof": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+            "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+            "dev": true
+        },
+        "strip-hex-prefix": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/strip-hex-prefix/-/strip-hex-prefix-1.0.0.tgz",
+            "integrity": "sha1-DF8VX+8RUTczd96du1iNoFUA428=",
+            "requires": {
+                "is-hex-prefixed": "1.0.0"
+            }
+        },
+        "strip-json-comments": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+            "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+            "dev": true
+        },
+        "supports-color": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+            "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+            "dev": true
+        },
+        "timed-out": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+            "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
+        },
+        "tslib": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
+            "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==",
+            "dev": true
+        },
+        "tslint": {
+            "version": "5.14.0",
+            "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.14.0.tgz",
+            "integrity": "sha512-IUla/ieHVnB8Le7LdQFRGlVJid2T/gaJe5VkjzRVSRR6pA2ODYrnfR1hmxi+5+au9l50jBwpbBL34txgv4NnTQ==",
+            "dev": true,
+            "requires": {
+                "babel-code-frame": "^6.22.0",
+                "builtin-modules": "^1.1.1",
+                "chalk": "^2.3.0",
+                "commander": "^2.12.1",
+                "diff": "^3.2.0",
+                "glob": "^7.1.1",
+                "js-yaml": "^3.7.0",
+                "minimatch": "^3.0.4",
+                "mkdirp": "^0.5.1",
+                "resolve": "^1.3.2",
+                "semver": "^5.3.0",
+                "tslib": "^1.8.0",
+                "tsutils": "^2.29.0"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "5.7.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+                    "dev": true
+                }
+            }
+        },
+        "tsutils": {
+            "version": "2.29.0",
+            "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
+            "integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
+            "dev": true,
+            "requires": {
+                "tslib": "^1.8.1"
+            }
+        },
+        "typescript": {
+            "version": "3.8.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+            "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
+            "dev": true
+        },
+        "underscore": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
+            "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
+        },
+        "universalify": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+            "dev": true
+        },
+        "url-set-query": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/url-set-query/-/url-set-query-1.0.0.tgz",
+            "integrity": "sha1-AW6M/Xwg7gXK/neV6JK9BwL6ozk="
+        },
+        "utf8": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
+            "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ=="
+        },
+        "which": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+            "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+            "dev": true,
+            "requires": {
+                "isexe": "^2.0.0"
+            }
+        },
+        "which-module": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+            "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+            "dev": true
+        },
+        "wrap-ansi": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+            "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+            "dev": true,
+            "requires": {
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+                    "dev": true
+                },
+                "is-fullwidth-code-point": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                    "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+                    "dev": true,
+                    "requires": {
+                        "number-is-nan": "^1.0.0"
+                    }
+                },
+                "string-width": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                    "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                    "dev": true,
+                    "requires": {
+                        "code-point-at": "^1.0.0",
+                        "is-fullwidth-code-point": "^1.0.0",
+                        "strip-ansi": "^3.0.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^2.0.0"
+                    }
+                }
+            }
+        },
+        "wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+        },
+        "xhr": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.5.0.tgz",
+            "integrity": "sha512-4nlO/14t3BNUZRXIXfXe+3N6w3s1KoxcJUUURctd64BLRe67E4gRwp4PjywtDY72fXpZ1y6Ch0VZQRY/gMPzzQ==",
+            "requires": {
+                "global": "~4.3.0",
+                "is-function": "^1.0.1",
+                "parse-headers": "^2.0.0",
+                "xtend": "^4.0.0"
+            }
+        },
+        "xhr-request": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/xhr-request/-/xhr-request-1.1.0.tgz",
+            "integrity": "sha512-Y7qzEaR3FDtL3fP30k9wO/e+FBnBByZeybKOhASsGP30NIkRAAkKD/sCnLvgEfAIEC1rcmK7YG8f4oEnIrrWzA==",
+            "requires": {
+                "buffer-to-arraybuffer": "^0.0.5",
+                "object-assign": "^4.1.1",
+                "query-string": "^5.0.1",
+                "simple-get": "^2.7.0",
+                "timed-out": "^4.0.1",
+                "url-set-query": "^1.0.0",
+                "xhr": "^2.0.4"
+            }
+        },
+        "xhr-request-promise": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/xhr-request-promise/-/xhr-request-promise-0.1.3.tgz",
+            "integrity": "sha512-YUBytBsuwgitWtdRzXDDkWAXzhdGB8bYm0sSzMPZT7Z2MBjMSTHFsyCT1yCRATY+XC69DUrQraRAEgcoCRaIPg==",
+            "requires": {
+                "xhr-request": "^1.1.0"
+            }
+        },
+        "xtend": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+            "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
+        },
+        "y18n": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+            "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+            "dev": true
+        },
+        "yargs": {
+            "version": "15.3.1",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.3.1.tgz",
+            "integrity": "sha512-92O1HWEjw27sBfgmXiixJWT5hRBp2eobqXicLtPBIDBhYB+1HpwZlXmbW2luivBJHBzki+7VyCLRtAkScbTBQA==",
+            "dev": true,
+            "requires": {
+                "cliui": "^6.0.0",
+                "decamelize": "^1.2.0",
+                "find-up": "^4.1.0",
+                "get-caller-file": "^2.0.1",
+                "require-directory": "^2.1.1",
+                "require-main-filename": "^2.0.0",
+                "set-blocking": "^2.0.0",
+                "string-width": "^4.2.0",
+                "which-module": "^2.0.0",
+                "y18n": "^4.0.0",
+                "yargs-parser": "^18.1.1"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "cliui": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+                    "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+                    "dev": true,
+                    "requires": {
+                        "string-width": "^4.2.0",
+                        "strip-ansi": "^6.0.0",
+                        "wrap-ansi": "^6.2.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "find-up": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+                    "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^5.0.0",
+                        "path-exists": "^4.0.0"
+                    }
+                },
+                "get-caller-file": {
+                    "version": "2.0.5",
+                    "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+                    "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+                    "dev": true
+                },
+                "is-fullwidth-code-point": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+                    "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+                    "dev": true
+                },
+                "locate-path": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+                    "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+                    "dev": true,
+                    "requires": {
+                        "p-locate": "^4.1.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+                    "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "^2.2.0"
+                    }
+                },
+                "path-exists": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+                    "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+                    "dev": true
+                },
+                "require-main-filename": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+                    "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "4.2.0",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+                    "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+                    "dev": true,
+                    "requires": {
+                        "emoji-regex": "^8.0.0",
+                        "is-fullwidth-code-point": "^3.0.0",
+                        "strip-ansi": "^6.0.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+                    "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^5.0.0"
+                    }
+                },
+                "wrap-ansi": {
+                    "version": "6.2.0",
+                    "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+                    "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.0.0",
+                        "string-width": "^4.1.0",
+                        "strip-ansi": "^6.0.0"
+                    }
+                },
+                "yargs-parser": {
+                    "version": "18.1.3",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+                    "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+                    "dev": true,
+                    "requires": {
+                        "camelcase": "^5.0.0",
+                        "decamelize": "^1.2.0"
+                    }
+                }
+            }
+        },
+        "yargs-parser": {
+            "version": "11.1.1",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
+            "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
+            "dev": true,
+            "requires": {
+                "camelcase": "^5.0.0",
+                "decamelize": "^1.2.0"
+            }
+        }
+    }
 }

--- a/packages/web3-utils/package.json
+++ b/packages/web3-utils/package.json
@@ -9,7 +9,7 @@
     },
     "types": "types/index.d.ts",
     "scripts": {
-        "dtslint": "dtslint types"
+        "dtslint": "dtslint --localTs node_modules/typescript/lib types"
     },
     "main": "src/index.js",
     "dependencies": {
@@ -23,7 +23,7 @@
         "utf8": "3.0.0"
     },
     "devDependencies": {
-        "definitelytyped-header-parser": "^3.9.0",
-        "dtslint": "^3.4.1"
+        "dtslint": "^3.4.1",
+        "typescript": "latest"
     }
 }

--- a/packages/web3-utils/types/index.d.ts
+++ b/packages/web3-utils/types/index.d.ts
@@ -20,8 +20,6 @@
  * @date 2018
  */
 
-// Minimum TypeScript Version: 3.0
-
 import BN = require('bn.js');
 
 export type Unit =

--- a/packages/web3/package-lock.json
+++ b/packages/web3/package-lock.json
@@ -220,16 +220,6 @@
 			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
 			"dev": true
 		},
-		"definitelytyped-header-parser": {
-			"version": "3.9.0",
-			"resolved": "https://registry.npmjs.org/definitelytyped-header-parser/-/definitelytyped-header-parser-3.9.0.tgz",
-			"integrity": "sha512-slbwZ5h5lasB12t+9EAGYr060aCMqEXp6cwD7CoTriK40HNDYU56/XQ6S4sbjBK8ReGRMnB/uDx0elKkb4kuQA==",
-			"dev": true,
-			"requires": {
-				"@types/parsimmon": "^1.3.0",
-				"parsimmon": "^1.2.0"
-			}
-		},
 		"diff": {
 			"version": "3.5.0",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
@@ -299,7 +289,6 @@
 				"json-stable-stringify": "^1.0.1",
 				"strip-json-comments": "^2.0.1",
 				"tslint": "5.14.0",
-				"typescript": "^3.9.0-dev.20200409",
 				"yargs": "^15.1.0"
 			},
 			"dependencies": {
@@ -312,6 +301,11 @@
 						"@types/parsimmon": "^1.3.0",
 						"parsimmon": "^1.2.0"
 					}
+				},
+				"typescript": {
+					"version": "3.9.0-dev.20200417",
+					"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.0-dev.20200417.tgz",
+					"integrity": "sha512-VjLaL/mz6HfZb76uFyxcMrT2HriDQErE28rC5g7owTmKGHnwl56OauZIIYqL0wQk6JkWCb54XC+oio3CQ1rHyA=="
 				}
 			}
 		},
@@ -861,9 +855,9 @@
 			}
 		},
 		"typescript": {
-			"version": "3.9.0-dev.20200409",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.0-dev.20200409.tgz",
-			"integrity": "sha512-S6rqgD9K1y3vva/2g6GSwtkg6RC8W74ssTq52NtpS/ujqptYOJIgWHnMK+QN9yjFk2fzJfH9/TIMeFnLkZyHZg==",
+			"version": "3.8.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+			"integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
 			"dev": true
 		},
 		"universalify": {

--- a/packages/web3/package.json
+++ b/packages/web3/package.json
@@ -19,7 +19,7 @@
     "author": "ethereum.org",
     "types": "types/index.d.ts",
     "scripts": {
-        "dtslint": "dtslint types",
+        "dtslint": "dtslint --localTs node_modules/typescript/lib types",
         "postinstall": "node angular-patch.js"
     },
     "authors": [
@@ -59,7 +59,7 @@
     },
     "devDependencies": {
         "@types/node": "^12.12.34",
-        "definitelytyped-header-parser": "^3.9.0",
-        "dtslint": "^3.4.1"
+        "dtslint": "^3.4.1",
+        "typescript": "latest"
     }
 }

--- a/packages/web3/types/index.d.ts
+++ b/packages/web3/types/index.d.ts
@@ -17,8 +17,6 @@
  * @date 2018
  */
 
-// Minimum TypeScript Version: 3.0
-
 import * as net from 'net';
 import { Bzz } from 'web3-bzz';
 import { BatchRequest, provider, Providers, Extension } from 'web3-core';


### PR DESCRIPTION
## Description

This PR fixes intermittent CI build failures due to `dtslint` erroring out on installing `3.9`.

As a workaround we install the latest `TypeScript` into each package and use `dtslint`'s `--localTs` option. It's not ideal since we only test the types against one version, but it was the existing behavior prior to https://github.com/ethereum/web3.js/pull/3464.